### PR TITLE
Max rate is now a package flag and start support for allowing monitoring

### DIFF
--- a/controller/tx_test.go
+++ b/controller/tx_test.go
@@ -41,7 +41,8 @@ func TestTxController_Limit(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			procPath = tt.procPath
 			device = "eth0"
-			tx, err := NewTxController(tt.limit)
+			maxRate = tt.limit
+			tx, err := NewTxController()
 			if !tt.wantErr && (err != nil) {
 				t.Errorf("NewTxController() got %v, want %t", err, tt.wantErr)
 				return
@@ -101,7 +102,8 @@ func TestNewTxController(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			device = tt.device
 			procPath = tt.procPath
-			got, err := NewTxController(tt.limit)
+			maxRate = tt.limit
+			got, err := NewTxController()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("NewTxController() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -145,7 +147,8 @@ func TestTxController_Watch(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			device = "eth0"
 			procPath = tt.procPath
-			tx, err := NewTxController(tt.limit)
+			maxRate = tt.limit
+			tx, err := NewTxController()
 			if err != nil {
 				t.Errorf("NewTxController() error = %v, want nil", err)
 				return


### PR DESCRIPTION
This change adds the -txcontroller.max-rate flag to the controller package. This change will allow the ndt-server to simply link against the library without defining flags in two locations.

This change also adds a new parameter to the tx controller `isLimited` logic that will allow monitoring requests to be allowed even when other requests would be rejected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/access/8)
<!-- Reviewable:end -->
