### PR TITLE
Set access token claim on HTTP request context

### DIFF
--- a/controller/control_test.go
+++ b/controller/control_test.go
@@ -3,25 +3,39 @@ package controller
 import (
 	"context"
 	"testing"
+
+	"gopkg.in/square/go-jose.v2/jwt"
 )
 
-func TestGetMonitoring(t *testing.T) {
-	// Set monitoring value true.
+func TestGetClaim(t *testing.T) {
+	// Set claim.
 	ctx := context.Background()
-	ctx = SetMonitoring(ctx, true)
-	if m := GetMonitoring(ctx); !m {
-		t.Errorf("Set/GetMonitoring() wrong; got %t, want %t", m, true)
+	cl := &jwt.Claims{}
+	ctx = SetClaim(ctx, cl)
+	if got := GetClaim(ctx); got == nil || got != cl {
+		t.Errorf("Set/GetClaim() wrong; got nil, want %v", cl)
 	}
 
-	// Set monitoring value false.
+	// Get claim from ctx without a value.
 	ctx = context.Background()
-	ctx = SetMonitoring(ctx, false)
-	if m := GetMonitoring(ctx); m {
-		t.Errorf("Set/GetMonitoring() wrong; got %t, want %t", m, false)
+	if cl := GetClaim(ctx); cl != nil {
+		t.Errorf("Set/GetClaim() wrong; got %v, want nil", cl)
 	}
 
 	// Verify that a nil context WAI.
-	if m := GetMonitoring(nil); m {
-		t.Errorf("Set/GetMonitoring() wrong; got %t, want %t", m, false)
+	if cl := GetClaim(nil); cl != nil {
+		t.Errorf("Set/GetClaim() wrong; got %v, want nil", cl)
+	}
+}
+
+func TestIsMonitoring(t *testing.T) {
+	cl := &jwt.Claims{
+		Issuer: monitorIssuer,
+	}
+	if !IsMonitoring(cl) {
+		t.Errorf("IsMonitoring() did not recognize monitoring issuer; got false, want true")
+	}
+	if IsMonitoring(nil) {
+		t.Errorf("IsMonitoring() did not recognize monitoring issuer; got true, want false")
 	}
 }

--- a/controller/control_test.go
+++ b/controller/control_test.go
@@ -30,7 +30,8 @@ func TestGetClaim(t *testing.T) {
 
 func TestIsMonitoring(t *testing.T) {
 	cl := &jwt.Claims{
-		Issuer: monitorIssuer,
+		Issuer:  tokenIssuer,
+		Subject: monitorSubject,
 	}
 	if !IsMonitoring(cl) {
 		t.Errorf("IsMonitoring() did not recognize monitoring issuer; got false, want true")

--- a/controller/token_test.go
+++ b/controller/token_test.go
@@ -64,6 +64,7 @@ func TestTokenController_Limit(t *testing.T) {
 			verifier: &fakeVerifier{
 				claims: &jwt.Claims{
 					Issuer:   tokenIssuer,
+					Subject:  monitorSubject,
 					Audience: []string{"mlab1.fake0"},
 					Expiry:   jwt.NewNumericDate(time.Now()),
 				},
@@ -71,7 +72,7 @@ func TestTokenController_Limit(t *testing.T) {
 			token:      "this-is-a-fake-token",
 			code:       http.StatusOK,
 			visited:    true,
-			monitoring: true, // because the Issuer == monitorIssuer.
+			monitoring: true, // because the Subject == monitorSubject.
 		},
 		{
 			name:    "error-failure-to-verify",

--- a/controller/token_test.go
+++ b/controller/token_test.go
@@ -36,8 +36,7 @@ func TestTokenController_Limit(t *testing.T) {
 			machine: "mlab1.fake0",
 			verifier: &fakeVerifier{
 				claims: &jwt.Claims{
-					Issuer:   monitorIssuer,
-					Subject:  "ndt",
+					Issuer:   tokenIssuer,
 					Audience: []string{"mlab1.fake0"},
 					Expiry:   jwt.NewNumericDate(time.Now()),
 				},
@@ -50,8 +49,7 @@ func TestTokenController_Limit(t *testing.T) {
 			machine: "mlab1.fake0",
 			verifier: &fakeVerifier{
 				claims: &jwt.Claims{
-					Issuer:   "locate.measurementlab.net",
-					Subject:  "ndt",
+					Issuer:   tokenIssuer,
 					Audience: []string{"mlab1.fake0"},
 					Expiry:   jwt.NewNumericDate(time.Now()),
 				},
@@ -65,8 +63,7 @@ func TestTokenController_Limit(t *testing.T) {
 			machine: "mlab1.fake0",
 			verifier: &fakeVerifier{
 				claims: &jwt.Claims{
-					Issuer:   monitorIssuer,
-					Subject:  "ndt",
+					Issuer:   tokenIssuer,
 					Audience: []string{"mlab1.fake0"},
 					Expiry:   jwt.NewNumericDate(time.Now()),
 				},
@@ -95,7 +92,7 @@ func TestTokenController_Limit(t *testing.T) {
 			isMonitoring := false
 			next := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 				visited = true
-				isMonitoring = GetMonitoring(req.Context())
+				isMonitoring = IsMonitoring(GetClaim(req.Context()))
 			})
 			req := httptest.NewRequest(http.MethodGet, "/", nil)
 			req.Form = url.Values{}

--- a/controller/tx.go
+++ b/controller/tx.go
@@ -115,8 +115,8 @@ func (tx *TxController) isLimited(proto string, monitoring bool) bool {
 // the next handler. If the rate is unspecified (zero), all requests are accepted.
 func (tx *TxController) Limit(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// TODO: discover whether monitoring is true from access token claim.
-		monitoring := false
+		// Discover whether the access token was issued for monitoring.
+		monitoring := IsMonitoring(GetClaim(r.Context()))
 		if tx.isLimited("http", monitoring) {
 			// 503 - https://tools.ietf.org/html/rfc7231#section-6.6.4
 			w.WriteHeader(http.StatusServiceUnavailable)


### PR DESCRIPTION
This changes how the token controller validates access tokens.

1. The token issuer is configured via a flag.
2. Claims are validated without an explicit "Subject".

   * The claim subject will be used differently for various use-cases, such as for monitoring, a specific IP address in the envelope service, or target service like "ndt".

3. Claims are saved in the HTTP request context value using `SetClaim()` and can be retrieved using `GetClaim()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/access/9)
<!-- Reviewable:end -->
