### PR TITLE
Add controller.Setup

### DIFF
--- a/controller/control.go
+++ b/controller/control.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 
+	// Alice package provides a light weight way to chain HTTP middleware functions.
 	"github.com/justinas/alice"
 	"gopkg.in/square/go-jose.v2/jwt"
 )
@@ -48,9 +49,12 @@ func IsMonitoring(cl *jwt.Claims) bool {
 	return cl.Subject == monitorSubject
 }
 
-// Setup creates sequence of access control http.Handlers. If the
-// verifier is nil then it will be excluded. If the tx controller is
-// unconfigured then it will be excluded.
+// Setup creates a sequence of access control http.Handlers. When the verifier
+// is nil then the token controller will be excluded from the returned handler
+// chain. When the tx controller is unconfigured then the tx controller will be
+// excluded from the returned handler chain. Setup returns the TxController
+// because it provides the Accepter interface for use by servers accepting raw
+// TCP connections. See TxController.Accept for more information.
 func Setup(ctx context.Context, v Verifier) (alice.Chain, *TxController) {
 	// Setup sequence of access control http.Handlers.
 	// Controllers must be applied in specific order:

--- a/controller/control.go
+++ b/controller/control.go
@@ -56,10 +56,11 @@ func IsMonitoring(cl *jwt.Claims) bool {
 // because it provides the Accepter interface for use by servers accepting raw
 // TCP connections. See TxController.Accept for more information.
 func Setup(ctx context.Context, v Verifier) (alice.Chain, *TxController) {
-	// Setup sequence of access control http.Handlers.
-	// Controllers must be applied in specific order:
-	// 1. access token - to validate client and monitoring requests
-	// 2. transmit - to make resource-aware decisions and allow monitoring
+	// Controllers must be applied in specific order so that the tx controller
+	// can access the access token claims (if present) to identify monitoring
+	// requests. When token validation is successful, the validated claims are
+	// added to the HTTP request context. The tx controller looks for claims in
+	// the request context to determine if a request is monitoring (to allow it).
 	ac := alice.New()
 
 	// If the verifier is not nil, include the token limit.

--- a/controller/control.go
+++ b/controller/control.go
@@ -4,8 +4,14 @@ package controller
 
 import (
 	"context"
+	"fmt"
+	"io"
 	"net/http"
+	"os"
+	"time"
 
+	"github.com/gorilla/handlers"
+	"github.com/justinas/alice"
 	"gopkg.in/square/go-jose.v2/jwt"
 )
 
@@ -44,4 +50,50 @@ func IsMonitoring(cl *jwt.Claims) bool {
 		return false
 	}
 	return cl.Subject == monitorSubject
+}
+
+// Setup creates sequence of access control http.Handlers. If the
+// verifier is nil then it will be excluded. If the tx controller is
+// unconfigured then it will be excluded.
+func Setup(ctx context.Context, v Verifier) (alice.Chain, *TxController) {
+	// Setup sequence of access control http.Handlers.
+	ac := alice.New()
+
+	// Controllers must be applied in specific order:
+	// 1. logging
+	// 2. access token handling
+	// 3. transmit handling - must follow tokens to identify and allow monitoring
+	ac = ac.Append(loggingHandler)
+
+	// If the verifier is not nil, include the token limit.
+	token, err := NewTokenController(v)
+	if err == nil {
+		ac = ac.Append(token.Limit)
+	}
+
+	// If the tx controller is successful, include the tx limit.
+	tx, err := NewTxController(ctx)
+	if err == nil {
+		ac = ac.Append(tx.Limit)
+	}
+
+	return ac, tx
+}
+
+func loggingHandler(next http.Handler) http.Handler {
+	return handlers.CustomLoggingHandler(os.Stderr, next, customFormat)
+}
+
+func customFormat(w io.Writer, p handlers.LogFormatterParams) {
+	// Remove the RawQuery to print less unnecessary information.
+	p.URL.RawQuery = ""
+	fmt.Fprintln(w,
+		p.Request.RemoteAddr,
+		p.TimeStamp.Format(time.RFC3339Nano),
+		p.Request.Proto,
+		p.Request.Method,
+		p.URL.String(),
+		p.StatusCode,
+		p.Size,
+	)
 }

--- a/controller/control.go
+++ b/controller/control.go
@@ -4,6 +4,7 @@ package controller
 
 import (
 	"context"
+	"log"
 	"net/http"
 
 	"github.com/justinas/alice"
@@ -61,12 +62,16 @@ func Setup(ctx context.Context, v Verifier) (alice.Chain, *TxController) {
 	token, err := NewTokenController(v)
 	if err == nil {
 		ac = ac.Append(token.Limit)
+	} else {
+		log.Printf("WARNING: token controller is disabled: %v", err)
 	}
 
 	// If the tx controller is successful, include the tx limit.
 	tx, err := NewTxController(ctx)
 	if err == nil {
 		ac = ac.Append(tx.Limit)
+	} else {
+		log.Printf("WARNING: tx controller is disabled: %v", err)
 	}
 
 	return ac, tx

--- a/controller/control_test.go
+++ b/controller/control_test.go
@@ -2,8 +2,11 @@ package controller
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/justinas/alice"
 	"gopkg.in/square/go-jose.v2/jwt"
 )
 
@@ -38,5 +41,61 @@ func TestIsMonitoring(t *testing.T) {
 	}
 	if IsMonitoring(nil) {
 		t.Errorf("IsMonitoring() did not recognize monitoring issuer; got true, want false")
+	}
+}
+
+func TestSetupDefault(t *testing.T) {
+	tests := []struct {
+		name     string
+		hostname string
+		v        *fakeVerifier
+		device   string
+		ac       alice.Chain
+		tx       *TxController
+		wantNil  bool
+	}{
+		{
+			name:    "success-logging-only",
+			v:       nil,
+			device:  "no-such-device",
+			wantNil: true,
+		},
+		{
+			name:     "success-all-controllers",
+			hostname: "mlab1.foo01",
+			v:        &fakeVerifier{},
+			device:   "eth0",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			// Use synthetic proc data to allow tests to work on any platform.
+			procPath = "testdata/proc-success"
+			device = tt.device
+			machine = tt.hostname
+			ac, tx := Setup(ctx, tt.v)
+			// The tx controller only works in linux; only report errors for linux.
+			if (tx != nil) == tt.wantNil {
+				t.Errorf("Setup() tx = %v, wantNil %v", tx, tt.wantNil)
+				return
+			}
+
+			visited := false
+			next := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+				visited = true
+			})
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			rw := httptest.NewRecorder()
+
+			ac.Then(next).ServeHTTP(rw, req)
+
+			if rw.Code != http.StatusOK {
+				t.Errorf("Setup() Then() wrong http code; got %d, want %d", rw.Code, http.StatusOK)
+			}
+			if !visited {
+				t.Errorf("Setup() Then() not visited; got false, want true")
+			}
+		})
 	}
 }

--- a/controller/token_test.go
+++ b/controller/token_test.go
@@ -84,10 +84,23 @@ func TestTokenController_Limit(t *testing.T) {
 			code:    http.StatusUnauthorized,
 			visited: false, // "next" handler is never visited.
 		},
+		{
+			name:     "error-nil-verifier",
+			machine:  "mlab1.fake0",
+			verifier: nil,
+			wantErr:  true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			token := NewTokenController(tt.machine, tt.verifier)
+			machine = tt.machine
+			token, err := NewTokenController(tt.verifier)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewTokenController() returned err; got %v, wantErr %t", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
 
 			visited := false
 			isMonitoring := false

--- a/controller/token_test.go
+++ b/controller/token_test.go
@@ -90,6 +90,14 @@ func TestTokenController_Limit(t *testing.T) {
 			verifier: nil,
 			wantErr:  true,
 		},
+		{
+			name:    "error-empty-machine",
+			machine: "",
+			verifier: &fakeVerifier{
+				err: fmt.Errorf("fake failure to verify"),
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/controller/tx.go
+++ b/controller/tx.go
@@ -48,7 +48,7 @@ type TxController struct {
 
 // NewTxController creates a new instance initialized to run every second.
 // Caller should run Watch in a goroutine to regularly update the current rate.
-func NewTxController() (*TxController, error) {
+func NewTxController(ctx context.Context) (*TxController, error) {
 	if device == "" {
 		return nil, ErrNoDevice
 	}
@@ -67,6 +67,8 @@ func NewTxController() (*TxController, error) {
 		pfs:    pfs,
 		period: 100 * time.Millisecond,
 	}
+	// Run watch in a goroutine.
+	go tx.Watch(ctx)
 	return tx, nil
 }
 

--- a/controller/tx.go
+++ b/controller/tx.go
@@ -46,8 +46,10 @@ type TxController struct {
 	pfs     procfs.FS
 }
 
-// NewTxController creates a new instance initialized to run every second.
-// Caller should run Watch in a goroutine to regularly update the current rate.
+// NewTxController creates a new instance and runs TxController.Watch in a
+// goroutine to observe the current rate every 100 msec. When the given context
+// is canceled or expires, Watch will return and the TxController will no longer
+// be updated until Watch is started again.
 func NewTxController(ctx context.Context) (*TxController, error) {
 	if device == "" {
 		return nil, ErrNoDevice

--- a/controller/tx_test.go
+++ b/controller/tx_test.go
@@ -42,14 +42,18 @@ func TestTxController_Limit(t *testing.T) {
 			procPath = tt.procPath
 			device = "eth0"
 			maxRate = tt.limit
-			ctx := context.Background()
-			tx, err := NewTxController(ctx)
-			if !tt.wantErr && (err != nil) {
-				t.Errorf("NewTxController() got %v, want %t", err, tt.wantErr)
-				return
+
+			pfs, err := procfs.NewFS(procPath)
+			rtx.Must(err, "Failed to allocate procfs")
+
+			tx := &TxController{
+				device:  device,
+				limit:   tt.limit,
+				pfs:     pfs,
+				period:  time.Millisecond,
+				current: tt.current,
 			}
-			tx.limit = tt.limit
-			tx.current = tt.current
+
 			visited := false
 			next := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 				visited = true


### PR DESCRIPTION
This change adds `controller.Setup` to provide consistent setup of the http access controller handlers for ndt-server, the envelope service, and other services integrating this functionality.

In order to simplify the logic in controller.Setup the interfaces of several existing controller types are changed in this PR. Since the m-lab/access package has no active users yet, no changes are breaking.

* NewTxController accepts a context in order to start the Watch goroutine immediately.
* NewTokenController uses the `machine` name provided by a flag to validate access tokens.
* Unit tests are updated accordingly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/access/10)
<!-- Reviewable:end -->
