### PR TITLE
Add package for address management using iptables

### DIFF
--- a/address/granter.go
+++ b/address/granter.go
@@ -1,0 +1,76 @@
+// Package address supports managing access for a small pool of IP addresses
+// using iptables.
+package address
+
+import (
+	"errors"
+	"net"
+	"time"
+
+	"golang.org/x/sync/semaphore"
+
+	"gopkg.in/m-lab/pipe.v3"
+)
+
+// IPManager supports granting IP access using iptables or ip6tables.
+type IPManager struct {
+	*semaphore.Weighted
+}
+
+// ErrMaxConcurrent is returned when the max concurrent grants has already been reached.
+var ErrMaxConcurrent = errors.New("max concurrent reached")
+
+// NewIPManager creates a new instance that will allow granting up to max IPs
+// concurrently. Due to overhead in iptable processing and the impact that could
+// have on measurements, max should be small.
+func NewIPManager(max int64) *IPManager {
+	return &IPManager{
+		Weighted: semaphore.NewWeighted(max),
+	}
+}
+
+// Grant adds an iptables/ip6tables rule to allow packets from the given IP on
+// the INPUT chain. On success, the caller must call Revoke to allow a new Grant
+// in the future.
+func (r *IPManager) Grant(ip net.IP) error {
+	if !r.TryAcquire(1) {
+		return ErrMaxConcurrent
+	}
+
+	// Note: use use 'insert' (rather than 'append') to place the new rule first, to
+	// a) cooperate with the rules in the environment, b) minimize the time a packet
+	// stays in the chain handling logic.
+	addRule := pipe.Script("Add rules to allow "+ip.String(), ipTable("insert", ip))
+	err := pipe.RunTimeout(addRule, 10*time.Second)
+	if err != nil {
+		// Release semaphore before returning. Note: this assumes that iptables
+		// cannot add a rule AND return an error.
+		r.Release(1)
+	}
+	return err
+}
+
+// Revoke removes the iptables/ip6tables rule previously granted for the same IP.
+func (r *IPManager) Revoke(ip net.IP) error {
+	delRule := pipe.Script("Remove rule to allow "+ip.String(), ipTable("delete", ip))
+	err := pipe.RunTimeout(delRule, 10*time.Second)
+	if err == nil {
+		// Only release semaphore if removing rule succeeds.
+		// NOTE: if the rule is not removed, then an error represents a leak.
+		r.Release(1)
+	}
+	return err
+}
+
+func ipTable(command string, ip net.IP) pipe.Pipe {
+	// Parameters are the same for IPv4 and IPv6 addresses, but the command is not.
+	cmd := cmdForIP(ip)
+	return pipe.Exec(cmd, "--"+command+"=INPUT", "--source="+ip.String(), "--jump=ACCEPT")
+}
+
+func cmdForIP(ip net.IP) string {
+	if ip.To4() != nil {
+		return "iptables"
+	}
+	return "ip6tables"
+}

--- a/address/granter.go
+++ b/address/granter.go
@@ -37,7 +37,7 @@ func (r *IPManager) Grant(ip net.IP) error {
 		return ErrMaxConcurrent
 	}
 
-	// Note: use use 'insert' (rather than 'append') to place the new rule first, to
+	// Note: use 'insert' (rather than 'append') to place the new rule first, to
 	// a) cooperate with the rules in the environment, b) minimize the time a packet
 	// stays in the chain handling logic.
 	addRule := pipe.Script("Add rules to allow "+ip.String(), ipTable("insert", ip))

--- a/address/granter_test.go
+++ b/address/granter_test.go
@@ -1,0 +1,81 @@
+package address
+
+import (
+	"net"
+	"os"
+	"testing"
+
+	"github.com/m-lab/go/osx"
+	"github.com/m-lab/go/rtx"
+)
+
+func TestIPGranter_Grant(t *testing.T) {
+	cwd, err := os.Getwd()
+	rtx.Must(err, "Failed to get cwd")
+	// Update PATH to prefer fake versions of iptables and ip6tables commands.
+	resetPath := osx.MustSetenv("PATH", cwd+"/testdata:"+os.Getenv("PATH"))
+	defer resetPath()
+
+	tests := []struct {
+		name          string
+		max           int64
+		ip            net.IP
+		grantExit     string
+		revokeExit    string
+		wantGrantErr  bool
+		wantRevokeErr bool
+	}{
+		{
+			name: "success-ipv4",
+			max:  1,
+			ip:   net.ParseIP("127.0.0.1"),
+		},
+		{
+			name: "success-ipv6",
+			max:  1,
+			ip:   net.ParseIP("2002::1"),
+		},
+		{
+			name:         "error-max-concurent",
+			max:          0, // Make first Grant fail.
+			ip:           net.ParseIP("127.0.0.1"),
+			wantGrantErr: true,
+		},
+		{
+			name:         "error-grant-iptables",
+			max:          1,
+			ip:           net.ParseIP("127.0.0.1"),
+			grantExit:    "1", // Make iptables exit with error during grant.
+			wantGrantErr: true,
+		},
+		{
+			name:          "error-revoke",
+			max:           1,
+			ip:            net.ParseIP("127.0.0.1"),
+			revokeExit:    "1", // Make iptables exit with error during revoke.
+			wantRevokeErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// NOTE: the fake iptables commands read and exit using the EXIT environment.
+			resetExit := osx.MustSetenv("EXIT", tt.grantExit)
+			defer resetExit()
+
+			r := NewIPGranter(tt.max)
+			if err := r.Grant(tt.ip); (err != nil) != tt.wantGrantErr {
+				t.Errorf("IPGranter.Grant() error = %v, wantErr %v", err, tt.wantGrantErr)
+				return
+			}
+			if tt.wantGrantErr {
+				return
+			}
+
+			resetExit = osx.MustSetenv("EXIT", tt.revokeExit)
+			defer resetExit()
+			if err := r.Revoke(tt.ip); (err != nil) != tt.wantRevokeErr {
+				t.Errorf("IPGranter.Revoke() error = %v, wantErr %v", err, tt.wantRevokeErr)
+			}
+		})
+	}
+}

--- a/address/granter_test.go
+++ b/address/granter_test.go
@@ -62,7 +62,7 @@ func TestIPGranter_Grant(t *testing.T) {
 			resetExit := osx.MustSetenv("EXIT", tt.grantExit)
 			defer resetExit()
 
-			r := NewIPGranter(tt.max)
+			r := NewIPManager(tt.max)
 			if err := r.Grant(tt.ip); (err != nil) != tt.wantGrantErr {
 				t.Errorf("IPGranter.Grant() error = %v, wantErr %v", err, tt.wantGrantErr)
 				return

--- a/address/testdata/ip6tables
+++ b/address/testdata/ip6tables
@@ -1,0 +1,3 @@
+#!/bin/bash
+EXIT=${EXIT:-0}
+exit $EXIT

--- a/address/testdata/ip6tables
+++ b/address/testdata/ip6tables
@@ -1,3 +1,2 @@
 #!/bin/bash
-EXIT=${EXIT:-0}
-exit $EXIT
+exit ${EXIT:-0}

--- a/address/testdata/iptables
+++ b/address/testdata/iptables
@@ -1,0 +1,3 @@
+#!/bin/bash
+EXIT=${EXIT:-0}
+exit $EXIT

--- a/address/testdata/iptables
+++ b/address/testdata/iptables
@@ -1,3 +1,2 @@
 #!/bin/bash
-EXIT=${EXIT:-0}
-exit $EXIT
+exit ${EXIT:-0}


### PR DESCRIPTION
This change adds a new package for managing access by client IPs using iptables rules.

The combination of `controller.Setup` and the `address.IPManager` allow building an access envelope service that accepts access tokens and grants limited access to a specific client IP.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/access/11)
<!-- Reviewable:end -->
