### PR TITLE
Make expected claims a parameter to NewTokenController

### DIFF
--- a/cmd/envelope/main.go
+++ b/cmd/envelope/main.go
@@ -31,6 +31,7 @@ var (
 	maxIPs      int64
 	certFile    string
 	keyFile     string
+	machine     string
 )
 
 func init() {
@@ -40,6 +41,8 @@ func init() {
 	flag.StringVar(&keyFile, "envelope.cert", "", "TLS certificate for envelope server")
 	flag.StringVar(&certFile, "envelope.key", "", "TLS key for envelope server")
 	flag.Var(&verifyKey, "envelope.verify-key", "Public key for verifying access tokens")
+	flag.StringVar(&machine, "envelope.machine", "", "The machine name to expect in access token claims")
+
 }
 
 type manager interface {
@@ -124,6 +127,7 @@ var getEnvelopeHandler = func() envelopeHandler {
 func main() {
 	flag.Parse()
 	log.SetFlags(log.LUTC | log.Lshortfile | log.LstdFlags)
+	rtx.Must(flagx.ArgsFromEnv(flag.CommandLine), "Could not parse env args")
 
 	prom := prometheusx.MustServeMetrics()
 	defer prom.Close()
@@ -132,7 +136,7 @@ func main() {
 	rtx.Must(err, "Failed to create token verifier")
 
 	env := getEnvelopeHandler()
-	ctl, _ := controller.Setup(mainCtx, verify)
+	ctl, _ := controller.Setup(mainCtx, verify, machine)
 	// Handle all requests using the alice http handler chaining library.
 	// Start with request logging.
 	ac := alice.New(logger).Extend(ctl)

--- a/cmd/envelope/main.go
+++ b/cmd/envelope/main.go
@@ -25,13 +25,14 @@ import (
 )
 
 var (
-	verifyKey   = flagx.FileBytes{}
-	listenAddr  string
-	removeAfter time.Duration
-	maxIPs      int64
-	certFile    string
-	keyFile     string
-	machine     string
+	verifyKey     = flagx.FileBytes{}
+	listenAddr    string
+	removeAfter   time.Duration
+	maxIPs        int64
+	certFile      string
+	keyFile       string
+	machine       string
+	requireTokens bool
 )
 
 func init() {
@@ -41,6 +42,7 @@ func init() {
 	flag.StringVar(&keyFile, "envelope.cert", "", "TLS certificate for envelope server")
 	flag.StringVar(&certFile, "envelope.key", "", "TLS key for envelope server")
 	flag.Var(&verifyKey, "envelope.verify-key", "Public key for verifying access tokens")
+	flag.BoolVar(&requireTokens, "envelope.require-tokens", true, "Require access token in requests")
 	flag.StringVar(&machine, "envelope.machine", "", "The machine name to expect in access token claims")
 
 }
@@ -136,7 +138,7 @@ func main() {
 	rtx.Must(err, "Failed to create token verifier")
 
 	env := getEnvelopeHandler()
-	ctl, _ := controller.Setup(mainCtx, verify, machine)
+	ctl, _ := controller.Setup(mainCtx, verify, requireTokens, machine)
 	// Handle all requests using the alice http handler chaining library.
 	// Start with request logging.
 	ac := alice.New(logger).Extend(ctl)

--- a/cmd/envelope/main.go
+++ b/cmd/envelope/main.go
@@ -42,7 +42,7 @@ func init() {
 	flag.StringVar(&keyFile, "envelope.cert", "", "TLS certificate for envelope server")
 	flag.StringVar(&certFile, "envelope.key", "", "TLS key for envelope server")
 	flag.Var(&verifyKey, "envelope.verify-key", "Public key for verifying access tokens")
-	flag.BoolVar(&requireTokens, "envelope.require-tokens", true, "Require access token in requests")
+	flag.BoolVar(&requireTokens, "envelope.token-required", true, "Require access token in requests")
 	flag.StringVar(&machine, "envelope.machine", "", "The machine name to expect in access token claims")
 
 }

--- a/cmd/envelope/main_test.go
+++ b/cmd/envelope/main_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io/ioutil"
+	"log"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -19,6 +21,11 @@ import (
 	"github.com/m-lab/go/flagx"
 	"github.com/m-lab/go/prometheusx"
 )
+
+func init() {
+	// Disable logging during unit testing.
+	log.SetOutput(ioutil.Discard)
+}
 
 func Test_main(t *testing.T) {
 	insecurePublicTestKey := `{"use":"sig","kty":"EC","kid":"112","crv":"P-256","alg":"ES256",` +

--- a/controller/control.go
+++ b/controller/control.go
@@ -55,7 +55,7 @@ func IsMonitoring(cl *jwt.Claims) bool {
 // excluded from the returned handler chain. Setup returns the TxController
 // because it provides the Accepter interface for use by servers accepting raw
 // TCP connections. See TxController.Accept for more information.
-func Setup(ctx context.Context, v Verifier, machine string) (alice.Chain, *TxController) {
+func Setup(ctx context.Context, v Verifier, required bool, machine string) (alice.Chain, *TxController) {
 	// Controllers must be applied in specific order so that the tx controller
 	// can access the access token claims (if present) to identify monitoring
 	// requests. When token validation is successful, the validated claims are
@@ -68,7 +68,7 @@ func Setup(ctx context.Context, v Verifier, machine string) (alice.Chain, *TxCon
 		Issuer:   "locate",
 		Audience: jwt.Audience{machine},
 	}
-	token, err := NewTokenController(v, false, exp)
+	token, err := NewTokenController(v, required, exp)
 	if err == nil {
 		ac = ac.Append(token.Limit)
 	} else {

--- a/controller/control.go
+++ b/controller/control.go
@@ -55,7 +55,7 @@ func IsMonitoring(cl *jwt.Claims) bool {
 // excluded from the returned handler chain. Setup returns the TxController
 // because it provides the Accepter interface for use by servers accepting raw
 // TCP connections. See TxController.Accept for more information.
-func Setup(ctx context.Context, v Verifier) (alice.Chain, *TxController) {
+func Setup(ctx context.Context, v Verifier, machine string) (alice.Chain, *TxController) {
 	// Controllers must be applied in specific order so that the tx controller
 	// can access the access token claims (if present) to identify monitoring
 	// requests. When token validation is successful, the validated claims are
@@ -64,7 +64,11 @@ func Setup(ctx context.Context, v Verifier) (alice.Chain, *TxController) {
 	ac := alice.New()
 
 	// If the verifier is not nil, include the token limit.
-	token, err := NewTokenController(v)
+	exp := jwt.Expected{
+		Issuer:   "locate",
+		Audience: jwt.Audience{machine},
+	}
+	token, err := NewTokenController(v, false, exp)
 	if err == nil {
 		ac = ac.Append(token.Limit)
 	} else {

--- a/controller/control.go
+++ b/controller/control.go
@@ -54,8 +54,10 @@ func IsMonitoring(cl *jwt.Claims) bool {
 // chain. When the tx controller is unconfigured then the tx controller will be
 // excluded from the returned handler chain. Setup returns the TxController
 // because it provides the Accepter interface for use by servers accepting raw
-// TCP connections. See TxController.Accept for more information.
-func Setup(ctx context.Context, v Verifier, required bool, machine string) (alice.Chain, *TxController) {
+// TCP connections. See TxController.Accept for more information. When
+// tokenRequired is true, then the token controller requires valid access tokens
+// for the named machine.
+func Setup(ctx context.Context, v Verifier, tokenRequired bool, machine string) (alice.Chain, *TxController) {
 	// Controllers must be applied in specific order so that the tx controller
 	// can access the access token claims (if present) to identify monitoring
 	// requests. When token validation is successful, the validated claims are
@@ -68,7 +70,7 @@ func Setup(ctx context.Context, v Verifier, required bool, machine string) (alic
 		Issuer:   "locate",
 		Audience: jwt.Audience{machine},
 	}
-	token, err := NewTokenController(v, required, exp)
+	token, err := NewTokenController(v, tokenRequired, exp)
 	if err == nil {
 		ac = ac.Append(token.Limit)
 	} else {

--- a/controller/control.go
+++ b/controller/control.go
@@ -12,6 +12,12 @@ import (
 	"gopkg.in/square/go-jose.v2/jwt"
 )
 
+// TODO: replace with constants from the locate service repository.
+const (
+	locateIssuer   = "locate"
+	monitorSubject = "monitoring"
+)
+
 // Controller is the interface that all access control types should implement.
 type Controller interface {
 	Limit(next http.Handler) http.Handler
@@ -39,8 +45,6 @@ func GetClaim(ctx context.Context) *jwt.Claims {
 	return value.(*jwt.Claims)
 }
 
-const monitorSubject = "monitoring"
-
 // IsMonitoring reports whether (possibly nil) claim is from a monitoring issuer.
 func IsMonitoring(cl *jwt.Claims) bool {
 	if cl == nil {
@@ -67,7 +71,7 @@ func Setup(ctx context.Context, v Verifier, tokenRequired bool, machine string) 
 
 	// If the verifier is not nil, include the token limit.
 	exp := jwt.Expected{
-		Issuer:   "locate",
+		Issuer:   locateIssuer,
 		Audience: jwt.Audience{machine},
 	}
 	token, err := NewTokenController(v, tokenRequired, exp)

--- a/controller/control_test.go
+++ b/controller/control_test.go
@@ -73,7 +73,7 @@ func TestSetupDefault(t *testing.T) {
 			// Use synthetic proc data to allow tests to work on any platform.
 			procPath = "testdata/proc-success"
 			device = tt.device
-			ac, tx := Setup(ctx, tt.v, tt.hostname)
+			ac, tx := Setup(ctx, tt.v, false, tt.hostname)
 			// The tx controller only works in linux; only report errors for linux.
 			if (tx != nil) == tt.wantNil {
 				t.Errorf("Setup() tx = %v, wantNil %v", tx, tt.wantNil)

--- a/controller/control_test.go
+++ b/controller/control_test.go
@@ -33,7 +33,7 @@ func TestGetClaim(t *testing.T) {
 
 func TestIsMonitoring(t *testing.T) {
 	cl := &jwt.Claims{
-		Issuer:  "locate",
+		Issuer:  locateIssuer,
 		Subject: monitorSubject,
 	}
 	if !IsMonitoring(cl) {

--- a/controller/control_test.go
+++ b/controller/control_test.go
@@ -33,7 +33,7 @@ func TestGetClaim(t *testing.T) {
 
 func TestIsMonitoring(t *testing.T) {
 	cl := &jwt.Claims{
-		Issuer:  tokenIssuer,
+		Issuer:  "locate",
 		Subject: monitorSubject,
 	}
 	if !IsMonitoring(cl) {
@@ -73,8 +73,7 @@ func TestSetupDefault(t *testing.T) {
 			// Use synthetic proc data to allow tests to work on any platform.
 			procPath = "testdata/proc-success"
 			device = tt.device
-			machine = tt.hostname
-			ac, tx := Setup(ctx, tt.v)
+			ac, tx := Setup(ctx, tt.v, tt.hostname)
 			// The tx controller only works in linux; only report errors for linux.
 			if (tx != nil) == tt.wantNil {
 				t.Errorf("Setup() tx = %v, wantNil %v", tx, tt.wantNil)

--- a/controller/token_test.go
+++ b/controller/token_test.go
@@ -34,11 +34,11 @@ func TestTokenController_Limit(t *testing.T) {
 	}{
 		{
 			name:    "success-without-token",
-			issuer:  "locate",
+			issuer:  locateIssuer,
 			machine: "mlab1.fake0",
 			verifier: &fakeVerifier{
 				claims: &jwt.Claims{
-					Issuer:   "locate",
+					Issuer:   locateIssuer,
 					Audience: []string{"mlab1.fake0"},
 					Expiry:   jwt.NewNumericDate(time.Now()),
 				},
@@ -48,11 +48,11 @@ func TestTokenController_Limit(t *testing.T) {
 		},
 		{
 			name:    "success-with-token",
-			issuer:  "locate",
+			issuer:  locateIssuer,
 			machine: "mlab1.fake0",
 			verifier: &fakeVerifier{
 				claims: &jwt.Claims{
-					Issuer:   "locate",
+					Issuer:   locateIssuer,
 					Audience: []string{"mlab1.fake0"},
 					Expiry:   jwt.NewNumericDate(time.Now()),
 				},
@@ -63,11 +63,11 @@ func TestTokenController_Limit(t *testing.T) {
 		},
 		{
 			name:    "success-with-token-with-monitoring-issuer",
-			issuer:  "locate",
+			issuer:  locateIssuer,
 			machine: "mlab1.fake0",
 			verifier: &fakeVerifier{
 				claims: &jwt.Claims{
-					Issuer:   "locate",
+					Issuer:   locateIssuer,
 					Subject:  monitorSubject,
 					Audience: []string{"mlab1.fake0"},
 					Expiry:   jwt.NewNumericDate(time.Now()),
@@ -80,7 +80,7 @@ func TestTokenController_Limit(t *testing.T) {
 		},
 		{
 			name:    "error-failure-to-verify",
-			issuer:  "locate",
+			issuer:  locateIssuer,
 			machine: "mlab1.fake0",
 			verifier: &fakeVerifier{
 				err: fmt.Errorf("fake failure to verify"),
@@ -91,14 +91,14 @@ func TestTokenController_Limit(t *testing.T) {
 		},
 		{
 			name:     "error-nil-verifier",
-			issuer:   "locate",
+			issuer:   locateIssuer,
 			machine:  "mlab1.fake0",
 			verifier: nil,
 			wantErr:  true,
 		},
 		{
 			name:    "error-empty-machine",
-			issuer:  "locate",
+			issuer:  locateIssuer,
 			machine: "",
 			verifier: &fakeVerifier{
 				err: fmt.Errorf("fake failure to verify"),


### PR DESCRIPTION
This change removes package flags for the token controller in favor of adding a parameter to NewTokenController to accept an expected claims for token verification.

This change will support more flexible reuse of the `controller.NewTokenController` in measurement services (like ndt-server) and in the locate service, while recognizing different issuers for monitoring and service heartbeats.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/access/15)
<!-- Reviewable:end -->
