### PR TITLE
Support Verifier with multiple keys

### DIFF
--- a/token/jwt.go
+++ b/token/jwt.go
@@ -4,14 +4,22 @@ package token
 
 import (
 	"errors"
+	"fmt"
 
 	jose "gopkg.in/square/go-jose.v2"
 	"gopkg.in/square/go-jose.v2/jwt"
 )
 
+// ErrTokenWithoutHeader is returned when trying to verify a token that has not header.
+var ErrTokenWithoutHeader = errors.New("Given token has not header")
+
+// ErrKeyIDNotFound is returned when trying to verify a token when there are no
+// corresponding key IDs matching the token header.
+var ErrKeyIDNotFound = errors.New("Key ID not found for given token header")
+
 // Verifier supports operations on a public JWK.
 type Verifier struct {
-	pub *jose.JSONWebKey
+	keys []*jose.JSONWebKey
 }
 
 // Signer supports operations on a private JWK.
@@ -39,15 +47,32 @@ func (k *Signer) Sign(cl jwt.Claims) (string, error) {
 	return k.Builder.Claims(cl).CompactSerialize()
 }
 
-// NewVerifier accepts a serialized, public JWK and creates a new Verifier instance.
-func NewVerifier(key []byte) (*Verifier, error) {
-	pub, err := LoadJSONWebKey(key, true)
-	if err != nil {
-		return nil, err
+// NewVerifier accepts serialized, public JWKs and creates a new Verifier
+// instance. Caller may pass multiple verifier keys to recognize and support
+// support key rotation of signer keys, or multiple issuers. When providing
+// multiple keys each should have a distinct "keyid". Behavior is undefined
+// when keys have the same keyid.
+func NewVerifier(keys ...[]byte) (*Verifier, error) {
+	pubKeys := []*jose.JSONWebKey{}
+	for i := range keys {
+		pub, err := LoadJSONWebKey(keys[i], true)
+		if err != nil {
+			return nil, err
+		}
+		pubKeys = append(pubKeys, pub)
 	}
 	return &Verifier{
-		pub: pub,
+		keys: pubKeys,
 	}, nil
+}
+
+func (k *Verifier) findKeyForKeyID(keyID string) *jose.JSONWebKey {
+	for i := range k.keys {
+		if k.keys[i].KeyID == keyID {
+			return k.keys[i]
+		}
+	}
+	return nil
 }
 
 // Claims extracts the claims from a signed token, but does not
@@ -58,9 +83,17 @@ func (k *Verifier) Claims(token string) (*jwt.Claims, error) {
 	if err != nil {
 		return nil, err
 	}
-	cl := &jwt.Claims{}
+	// NOTE: if ParseSigned returns without error, then we are guaranteed that
+	// at least one header is present. And, we will not support tokens with
+	// multiple signatures/headers.
+	keyID := obj.Headers[0].KeyID
+	pub := k.findKeyForKeyID(keyID)
+	if pub == nil {
+		return nil, fmt.Errorf("%w: %s", ErrKeyIDNotFound, keyID)
+	}
 	// Claims validates the jwt signature before extracting the token claims.
-	err = obj.Claims(k.pub, cl)
+	cl := &jwt.Claims{}
+	err = obj.Claims(pub, cl)
 	if err != nil {
 		return nil, err
 	}

--- a/token/jwt.go
+++ b/token/jwt.go
@@ -10,9 +10,6 @@ import (
 	"gopkg.in/square/go-jose.v2/jwt"
 )
 
-// ErrTokenWithoutHeader is returned when trying to verify a token that has not header.
-var ErrTokenWithoutHeader = errors.New("Given token has not header")
-
 // ErrKeyIDNotFound is returned when trying to verify a token when there are no
 // corresponding key IDs matching the token header.
 var ErrKeyIDNotFound = errors.New("Key ID not found for given token header")

--- a/token/jwt_test.go
+++ b/token/jwt_test.go
@@ -112,11 +112,18 @@ func TestVerifyErrors(t *testing.T) {
 				"iJdLCJleHAiOjE1Nzk5MTc3MzksImlzcyI6ImxvY2F0ZS5tZWFzdXJlbWVudGxhYi5uZXQiLCJqdGkiOiJ3aGF" +
 				"0d2hhdCIsInN1YiI6Im5kdCJ9.07Wmg_G-lDDuPz0dLsuXjZLZN8w37BGIN1RTUK4rSJ-3OIFtsZ9b7pVS0uHPUrD0kW9mbuv0Ouu_eD0v88Bp-w",
 		},
+		{
+			name: "error-verify-token-without-keyid",
+			// same token as above with the header replaced with an empty "{}" object.
+			token: "e30K.eyJhdWQiOlsibWxhYjEubGdhMDMiLCJtbGFiMi5hdGwwM" +
+				"iJdLCJleHAiOjE1Nzk5MTc3MzksImlzcyI6ImxvY2F0ZS5tZWFzdXJlbWVudGxhYi5uZXQiLCJqdGkiOiJ3aGF" +
+				"0d2hhdCIsInN1YiI6Im5kdCJ9.07Wmg_G-lDDuPz0dLsuXjZLZN8w37BGIN1RTUK4rSJ-3OIFtsZ9b7pVS0uHPUrD0kW9mbuv0Ouu_eD0v88Bp-w",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			k := &Verifier{
-				pub: key,
+				keys: []*jose.JSONWebKey{key},
 			}
 			_, err := k.Verify(tt.token, jwt.Expected{})
 			if err == nil {

--- a/token/jwt_test.go
+++ b/token/jwt_test.go
@@ -18,13 +18,14 @@ func TestSignAndVerify(t *testing.T) {
 	insecurePublicTestKey := `{"use":"sig","kty":"EC","kid":"112","crv":"P-256","alg":"ES256",` +
 		`"x":"V0NoRfUZ-fPACALnakvKtTyXJ5JtgAWlWm-0NaDWUOE","y":"RDbGu6RVhgJGKCTuya4_IzZhT1GzlEIA5ZkumEZ35Ag"}`
 	tests := []struct {
-		name          string
-		skey          string
-		vkey          string
-		cl            jwt.Claims
-		exp           jwt.Expected
-		wantSignErr   bool
-		wantVerifyErr bool
+		name                string
+		skey                string
+		vkey                string
+		cl                  jwt.Claims
+		exp                 jwt.Expected
+		wantSignErr         bool
+		wantVerifyErr       bool
+		wantDuplicateKeyErr bool
 	}{
 		{
 			name: "success",
@@ -57,6 +58,18 @@ func TestSignAndVerify(t *testing.T) {
 			},
 			wantVerifyErr: true,
 		},
+		{
+			name: "error-bad-verify-key",
+			skey: insecurePrivateTestKey,
+			vkey: insecurePublicTestKey,
+			cl: jwt.Claims{
+				Issuer:   "issuer",
+				Audience: []string{"mlab1", "mlab2"},
+				Expiry:   jwt.NewNumericDate(time.Date(2019, time.December, 1, 1, 2, 0, 0, time.UTC).Add(time.Minute)),
+			},
+			wantVerifyErr:       true,
+			wantDuplicateKeyErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -73,7 +86,15 @@ func TestSignAndVerify(t *testing.T) {
 				t.Fatalf("Failed to sign claim: %#v", tt.cl)
 			}
 
-			v, err := NewVerifier([]byte(tt.vkey))
+			keys := [][]byte{
+				[]byte(tt.vkey),
+			}
+			if tt.wantDuplicateKeyErr {
+				// Append the verify key twice so there is a duplicate keyid.
+				keys = append(keys, []byte(tt.vkey))
+			}
+
+			v, err := NewVerifier(keys...)
 			if tt.wantVerifyErr != (err != nil) {
 				t.Fatalf("NewVerifier failed to parse key: %v", err)
 			}
@@ -123,7 +144,7 @@ func TestVerifyErrors(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			k := &Verifier{
-				keys: []*jose.JSONWebKey{key},
+				keys: map[string]*jose.JSONWebKey{"112": key},
 			}
 			_, err := k.Verify(tt.token, jwt.Expected{})
 			if err == nil {

--- a/token/jwt_test.go
+++ b/token/jwt_test.go
@@ -59,7 +59,7 @@ func TestSignAndVerify(t *testing.T) {
 			wantVerifyErr: true,
 		},
 		{
-			name: "error-bad-verify-key",
+			name: "error-duplicate-verify-key-id",
 			skey: insecurePrivateTestKey,
 			vkey: insecurePublicTestKey,
 			cl: jwt.Claims{


### PR DESCRIPTION
This change adds support for creating a token.Verifier from multiple public keys. This change is backward compatible with existing clients by using a variadic parameter to `NewVerifier`.

This functionality will allow support signer key rotations: add verifier for the current and future signer key, followed by updating the signer key.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/access/16)
<!-- Reviewable:end -->
