### PR TITLE
Add Dockerfile for building access envelope

### DIFF
--- a/Dockerfile.envelope
+++ b/Dockerfile.envelope
@@ -1,0 +1,12 @@
+# Built the command using a golang base image.
+FROM golang:1.14.4-alpine3.12 AS build
+RUN apk add git
+ADD . /go/src/github.com/m-lab/access
+RUN go get -v github.com/m-lab/access/cmd/envelope
+
+# Now copy the resulting command into the minimal base image.
+FROM alpine:3.12
+COPY --from=build /go/bin/envelope /
+WORKDIR /
+RUN apk add --no-cache iptables ip6tables ca-certificates && update-ca-certificates
+ENTRYPOINT ["/envelope"]


### PR DESCRIPTION
This change adds a basic Dockerfile for building the access envelope container. This is very nearly all that is needed to enable envelope-protected services such as iperf, wehe, and others that do not have native `access_token` support.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/access/20)
<!-- Reviewable:end -->
