### PR TITLE
Add websocket support to access envelope

### DIFF
--- a/address/granter.go
+++ b/address/granter.go
@@ -12,6 +12,14 @@ import (
 	"gopkg.in/m-lab/pipe.v3"
 )
 
+// Manager manages access to a device by IP and port.
+type Manager interface {
+	Start(port, device string) error
+	Grant(ip net.IP) error
+	Revoke(ip net.IP) error
+	Stop() ([]byte, error)
+}
+
 // IPManager supports granting IP subnet access using iptables or ip6tables.
 type IPManager struct {
 	*semaphore.Weighted
@@ -74,4 +82,27 @@ func cmdForIP(ip net.IP) (string, string) {
 		return iptables, "/24"
 	}
 	return iptables, "/64"
+}
+
+// NullManager implements the address.Manager interface while doing nothing.
+type NullManager struct{}
+
+// Grant does nothing with the given ip.
+func (r *NullManager) Grant(ip net.IP) error {
+	return nil
+}
+
+// Revoke does nothing with the given ip.
+func (r *NullManager) Revoke(ip net.IP) error {
+	return nil
+}
+
+// Start does nothing to the given port or device.
+func (r *NullManager) Start(port, device string) error {
+	return nil
+}
+
+// Stop does nothing.
+func (r *NullManager) Stop() ([]byte, error) {
+	return nil, nil
 }

--- a/address/granter_test.go
+++ b/address/granter_test.go
@@ -101,3 +101,22 @@ func TestIPManager(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+// TestNullManager verifies that the NullManager does nothing.
+func TestNullManager(t *testing.T) {
+	t.Run("null-manager", func(t *testing.T) {
+		r := &NullManager{}
+		if err := r.Grant(net.ParseIP("127.0.0.1")); err != nil {
+			t.Errorf("NullManager.Grant() error = %v, want nil", err)
+		}
+		if err := r.Revoke(net.ParseIP("127.0.0.1")); err != nil {
+			t.Errorf("NullManager.Revoke() error = %v, want nil", err)
+		}
+		if err := r.Start("1234", "eth0"); err != nil {
+			t.Errorf("NullManager.Start() error = %v, want nil", err)
+		}
+		if _, err := r.Stop(); err != nil {
+			t.Errorf("NullManager.Stop() error = %v, want nil", err)
+		}
+	})
+}

--- a/chanio/reader.go
+++ b/chanio/reader.go
@@ -7,7 +7,7 @@ func ReadOnce(r io.Reader) <-chan struct{} {
 	c := make(chan struct{})
 	go func() {
 		b := make([]byte, 1)
-		// Block on read. Will return on EOF or when client sends data (which we don't want).
+		// Block on read. Will return on EOF or when client sends data (which is discarded).
 		r.Read(b)
 		// Close channel to send reader a signal.
 		close(c)

--- a/chanio/reader.go
+++ b/chanio/reader.go
@@ -1,0 +1,16 @@
+package chanio
+
+import "io"
+
+// ReadOnce reads from the given reader once and closes the returned channel. All data is discarded.
+func ReadOnce(r io.Reader) <-chan struct{} {
+	c := make(chan struct{})
+	go func() {
+		b := make([]byte, 1)
+		// Block on read. Will return on EOF or when client sends data (which we don't want).
+		r.Read(b)
+		// Close channel to send reader a signal.
+		close(c)
+	}()
+	return c
+}

--- a/chanio/reader_test.go
+++ b/chanio/reader_test.go
@@ -1,0 +1,25 @@
+package chanio
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+)
+
+func TestReadOnce(t *testing.T) {
+	t.Run("okay", func(t *testing.T) {
+		b := bytes.NewBufferString("message")
+		got := ReadOnce(b)
+		// Absolute timeout. Should never be reached.
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		select {
+		case <-got:
+			// success
+		case <-ctx.Done():
+			t.Errorf("ReadOnce() = context should never timeout")
+		}
+	})
+}

--- a/cmd/envelope/README.md
+++ b/cmd/envelope/README.md
@@ -94,3 +94,26 @@ eyJhdWQiOlsibWxhYjEubGdhMDMiXSwiZXhwIjoxNTg0NTAyMjEyLCJpc3MiOiJsb2NhdGUubWVhc3Vy
 nRsYWIubmV0Iiwic3ViIjoiMTI3LjAuMC4yIn0.FZSjjDjWJVGSKzJKJP5Cbaacp8PNqGX5_zETe3SQsXvhlo
 hGlAlKLdhDkjBDIKttXkO3BL5xyQ09cVGfmbelDA
 ```
+
+### Local development without access tokens
+
+Start the access envelope server, without requiring access tokens (and
+without iptables management; by default these are both required).
+
+```sh
+~/bin/envelope -envelope.token-required=false
+```
+
+Connect to the local access envelope using `curl`. When tokens are not
+required, the default timeout is 60s. After this timeout, the server will
+hangup automatically.
+
+```sh
+curl --no-buffer \
+  --header "Connection: Upgrade" \
+  --header "Upgrade: websocket" \
+  --header "Sec-WebSocket-Protocol: net.measurementlab.envelope" \
+  --header "Sec-WebSocket-Version: 13" \
+  --header "Sec-WebSocket-Key: aGVsbG8K" \
+  http://localhost:8880/v0/envelope/access
+```

--- a/cmd/envelope/README.md
+++ b/cmd/envelope/README.md
@@ -115,5 +115,5 @@ curl --no-buffer \
   --header "Sec-WebSocket-Protocol: net.measurementlab.envelope" \
   --header "Sec-WebSocket-Version: 13" \
   --header "Sec-WebSocket-Key: aGVsbG8K" \
-  http://localhost:8880/v0/envelope/access
+    http://localhost:8880/v0/envelope/access
 ```

--- a/cmd/envelope/main.go
+++ b/cmd/envelope/main.go
@@ -185,8 +185,8 @@ func setupConn(writer http.ResponseWriter, request *http.Request) *websocket.Con
 }
 
 func (env *envelopeHandler) wait(ctx context.Context, c *websocket.Conn, dl time.Time) {
-	// NOTE: we are explicitly ignoring the error value from SetDeadline to
-	// guarantee that we execute env.Revoke.
+	// NOTE: we are explicitly ignoring the error value from SetDeadline.
+	// Any error there will show up on read below.
 	c.SetReadDeadline(dl)
 	c.SetWriteDeadline(dl)
 	ctxdl, cancel := context.WithDeadline(ctx, dl)

--- a/cmd/envelope/main_test.go
+++ b/cmd/envelope/main_test.go
@@ -192,16 +192,27 @@ func Test_envelopeHandler_AllowRequest_Websocket(t *testing.T) {
 	tests := []struct {
 		name  string
 		code  int
+		sleep time.Duration
 		claim *jwt.Claims
 	}{
 		{
-			name: "success",
+			name: "success-exit-fast",
 			code: http.StatusSwitchingProtocols,
 			claim: &jwt.Claims{
 				Issuer:  "locate",
 				Subject: subject,
 				Expiry:  jwt.NewNumericDate(time.Now().Add(time.Second)),
 			},
+		},
+		{
+			name: "success-wait-for-timeout",
+			code: http.StatusSwitchingProtocols,
+			claim: &jwt.Claims{
+				Issuer:  "locate",
+				Subject: subject,
+				Expiry:  jwt.NewNumericDate(time.Now().Add(time.Second)),
+			},
+			sleep: 2 * time.Second, // 2x as long as the expiration time.
 		},
 	}
 	for _, tt := range tests {
@@ -238,6 +249,7 @@ func Test_envelopeHandler_AllowRequest_Websocket(t *testing.T) {
 				t.Errorf("AllowRequest() wrong status code; got %d, want %d", resp.StatusCode, tt.code)
 			}
 			if c != nil {
+				time.Sleep(tt.sleep)
 				c.Close()
 			}
 		})

--- a/cmd/envelope/main_test.go
+++ b/cmd/envelope/main_test.go
@@ -12,10 +12,13 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/gorilla/handlers"
+	"github.com/gorilla/websocket"
+	"github.com/justinas/alice"
 	"gopkg.in/square/go-jose.v2/jwt"
 
 	"github.com/m-lab/access/address"
@@ -60,6 +63,7 @@ func Test_main(t *testing.T) {
 	mainCtx, mainCancel = context.WithCancel(context.Background())
 	certFile = "testdata/insecure-cert.pem"
 	keyFile = "testdata/insecure-key.pem"
+	requireTokens = false // use NullManager.
 	mainCancel()
 	main()
 }
@@ -75,31 +79,48 @@ func (f *fakeManager) Revoke(ip net.IP) error {
 	return nil
 }
 
-func Test_envelopeHandler_AllowRequest(t *testing.T) {
+// Test_envelopeHandler_AllowRequest_Errors exercises error paths that cannot be
+// reached using the websocket client package directly.
+func Test_envelopeHandler_AllowRequest_Errors(t *testing.T) {
 	subject := "envelope"
 	tests := []struct {
-		name     string
-		param    string
-		method   string
-		remote   string
-		code     int
-		claim    *jwt.Claims
-		grantErr error
+		name            string
+		method          string
+		remote          string
+		code            int
+		allowEmptyClaim bool
+		claim           *jwt.Claims
+		grantErr        error
 	}{
 		{
 			name:   "error-bad-method",
-			method: http.MethodGet,
+			method: http.MethodPost,
 			code:   http.StatusMethodNotAllowed,
 		},
 		{
 			name:   "error-no-claim-found",
-			method: http.MethodPost,
-			code:   http.StatusInternalServerError,
+			method: http.MethodGet,
+			code:   http.StatusBadRequest,
+			remote: "127.0.0.2:1234",
+		},
+		{
+			name:            "error-allow-empty-claim",
+			method:          http.MethodGet,
+			code:            http.StatusBadRequest,
+			allowEmptyClaim: true,
+			remote:          "127.0.0.2:1234",
+		},
+		{
+			name:   "error-remote-host-corrupt",
+			method: http.MethodGet,
+			code:   http.StatusBadRequest,
+			remote: "thisisnotanip-1234",
 		},
 		{
 			name:   "error-claim-subject-is-invalid",
-			method: http.MethodPost,
+			method: http.MethodGet,
 			code:   http.StatusBadRequest,
+			remote: "127.0.0.2:1234",
 			claim: &jwt.Claims{
 				Issuer:  "locate",
 				Subject: "wrong-subject",
@@ -107,7 +128,7 @@ func Test_envelopeHandler_AllowRequest(t *testing.T) {
 		},
 		{
 			name:   "error-claim-is-already-expired",
-			method: http.MethodPost,
+			method: http.MethodGet,
 			code:   http.StatusBadRequest,
 			remote: "127.0.0.2:1234",
 			claim: &jwt.Claims{
@@ -118,7 +139,7 @@ func Test_envelopeHandler_AllowRequest(t *testing.T) {
 		},
 		{
 			name:   "error-grant-ip-failure-max-concurrent",
-			method: http.MethodPost,
+			method: http.MethodGet,
 			code:   http.StatusServiceUnavailable,
 			remote: "127.0.0.2:1234",
 			claim: &jwt.Claims{
@@ -129,20 +150,8 @@ func Test_envelopeHandler_AllowRequest(t *testing.T) {
 			grantErr: address.ErrMaxConcurrent,
 		},
 		{
-			name:   "error-split-host-port-failure",
-			method: http.MethodPost,
-			code:   http.StatusBadRequest,
-			remote: "corrupt-remote-ip",
-			claim: &jwt.Claims{
-				Issuer:  "locate",
-				Subject: subject,
-				Expiry:  jwt.NewNumericDate(time.Now().Add(time.Minute)),
-			},
-			grantErr: address.ErrMaxConcurrent,
-		},
-		{
 			name:   "error-grant-ip-failure-",
-			method: http.MethodPost,
+			method: http.MethodGet,
 			code:   http.StatusInternalServerError,
 			remote: "127.0.0.2:1234",
 			claim: &jwt.Claims{
@@ -152,11 +161,42 @@ func Test_envelopeHandler_AllowRequest(t *testing.T) {
 			},
 			grantErr: errors.New("generic grant error"),
 		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rw := httptest.NewRecorder()
+			req := httptest.NewRequest(tt.method, "/v0/envelope/access", nil)
+			env := &envelopeHandler{
+				manager: &fakeManager{
+					grantErr: tt.grantErr,
+				},
+				subject: "envelope",
+			}
+			requireTokens = !tt.allowEmptyClaim
+			if tt.claim != nil {
+				req = req.Clone(controller.SetClaim(req.Context(), tt.claim))
+			}
+
+			req.RemoteAddr = tt.remote
+			env.AllowRequest(rw, req)
+
+			if tt.code != rw.Code {
+				t.Errorf("AllowRequest() wrong status code; got %d, want %d", rw.Code, tt.code)
+			}
+		})
+	}
+}
+
+func Test_envelopeHandler_AllowRequest_Websocket(t *testing.T) {
+	subject := "envelope"
+	tests := []struct {
+		name  string
+		code  int
+		claim *jwt.Claims
+	}{
 		{
-			name:   "success",
-			method: http.MethodPost,
-			code:   http.StatusOK,
-			remote: "127.0.0.2:1234",
+			name: "success",
+			code: http.StatusSwitchingProtocols,
 			claim: &jwt.Claims{
 				Issuer:  "locate",
 				Subject: subject,
@@ -166,22 +206,39 @@ func Test_envelopeHandler_AllowRequest(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rw := httptest.NewRecorder()
-			req := httptest.NewRequest(tt.method, "/v0/envelope/access"+tt.param, nil)
 			env := &envelopeHandler{
-				manager: &fakeManager{
-					grantErr: tt.grantErr,
-				},
+				manager: &fakeManager{},
 				subject: "envelope",
 			}
-			if tt.claim != nil {
-				req = req.Clone(controller.SetClaim(req.Context(), tt.claim))
-			}
-			req.RemoteAddr = tt.remote
-			env.AllowRequest(rw, req)
+			requireTokens = true
 
-			if tt.code != rw.Code {
-				t.Errorf("AllowRequest() wrong status code; got %d, want %d", rw.Code, tt.code)
+			// Create a synthetic token claim handler that adds the unit test
+			// claim to the request context. It is simpler to inject the claim
+			// instead of invoking the PKI needed to sign and verify a real claim.
+			addClaims := func(next http.Handler) http.Handler {
+				return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					// Unconditionally assign the unit test claim to the request context.
+					next.ServeHTTP(w, r.Clone(controller.SetClaim(r.Context(), tt.claim)))
+				})
+			}
+			//
+			ac := alice.New(addClaims).Then(http.HandlerFunc(env.AllowRequest))
+
+			mux := http.NewServeMux()
+			mux.Handle("/v0/envelope/access", ac)
+
+			srv := httptest.NewServer(mux)
+			defer srv.Close()
+
+			headers := http.Header{}
+			headers.Add("Sec-WebSocket-Protocol", "net.measurementlab.envelope")
+			c, resp, _ := websocket.DefaultDialer.Dial(
+				strings.Replace(srv.URL, "http", "ws", 1)+"/v0/envelope/access", headers)
+			if tt.code != resp.StatusCode {
+				t.Errorf("AllowRequest() wrong status code; got %d, want %d", resp.StatusCode, tt.code)
+			}
+			if c != nil {
+				c.Close()
 			}
 		})
 	}


### PR DESCRIPTION
This change adds websocket support to the access envelope to simplify client development.

This change also adds an `address.NullManager` to disable iptables management when `-envelop.tokens-required=false`. Without this addition, the default `address.Manager` blocks all network access.

This change introduces a new package with `chanio.ReadOnce` that supports reading from an io.Reader via a returned channel. This allows callers to use a `select` loop with other channels.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/access/21)
<!-- Reviewable:end -->
