### PR TITLE
Add support for ipv4 and ipv6 dual stack management

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,6 @@ install:
 
 script:
 - go vet ./...
-- go test ./... -cover=1 -coverprofile=_c.cov
+- go test ./... -v -cover=1 -coverprofile=_c.cov
 - go test ./... -race
 - $GOPATH/bin/goveralls -service=travis-ci -coverprofile=_c.cov

--- a/address/granter_test.go
+++ b/address/granter_test.go
@@ -61,9 +61,9 @@ func TestIPManager_Grant(t *testing.T) {
 			defer osx.MustSetenv("IPTABLES_EXIT", tt.grantExit)()
 
 			if tt.ip.To4() != nil {
-				iptables = "./testdata/iptables"
+				ip4tables = "./testdata/iptables"
 			} else {
-				iptables = "./testdata/ip6tables"
+				ip6tables = "./testdata/ip6tables"
 			}
 
 			r := NewIPManager(tt.max)
@@ -84,7 +84,7 @@ func TestIPManager_Grant(t *testing.T) {
 }
 
 func TestIPManager(t *testing.T) {
-	iptables = "./testdata/iptables"
+	ip4tables = "./testdata/iptables"
 	wg := sync.WaitGroup{}
 	mgr := NewIPManager(10)
 	ip := net.ParseIP("127.0.0.2")

--- a/address/granter_test.go
+++ b/address/granter_test.go
@@ -59,6 +59,7 @@ func TestIPManager_Grant(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// NOTE: the fake iptables commands read and exit using the EXIT environment.
 			defer osx.MustSetenv("IPTABLES_EXIT", tt.grantExit)()
+			defer osx.MustSetenv("IP6TABLES_EXIT", tt.grantExit)()
 
 			if tt.ip.To4() != nil {
 				ip4tables = "./testdata/iptables"

--- a/address/setup_test.go
+++ b/address/setup_test.go
@@ -7,25 +7,41 @@ import (
 )
 
 func TestIPManager_Start(t *testing.T) {
-	iptables = "./testdata/iptables"
-	iptablesSave = "./testdata/iptables-save"
+	ip4tables = "./testdata/iptables"
+	ip4tablesSave = "./testdata/iptables-save"
+	ip6tables = "./testdata/ip6tables"
+	ip6tablesSave = "./testdata/ip6tables-save"
 
 	tests := []struct {
-		name             string
-		iptablesSaveCode string
-		iptablesCode     string
-		wantErr          bool
+		name              string
+		iptablesSaveCode  string
+		iptablesCode      string
+		iptablesSaveCode6 string
+		iptablesCode6     string
+		wantErr           bool
 	}{
 		{
-			name:             "success",
-			iptablesSaveCode: "0",
-			iptablesCode:     "0",
+			name:              "success",
+			iptablesSaveCode:  "0",
+			iptablesCode:      "0",
+			iptablesSaveCode6: "0",
+			iptablesCode6:     "0",
 		},
 		{
-			name:             "success",
-			iptablesSaveCode: "1",
-			iptablesCode:     "0",
-			wantErr:          true,
+			name:              "error-save-ipv4-failure",
+			iptablesSaveCode:  "1",
+			iptablesCode:      "0",
+			iptablesSaveCode6: "0",
+			iptablesCode6:     "0",
+			wantErr:           true,
+		},
+		{
+			name:              "error-save-ipv6-failure",
+			iptablesSaveCode:  "0",
+			iptablesCode:      "0",
+			iptablesSaveCode6: "1",
+			iptablesCode6:     "0",
+			wantErr:           true,
 		},
 	}
 	for _, tt := range tests {
@@ -33,6 +49,9 @@ func TestIPManager_Start(t *testing.T) {
 			r := &IPManager{}
 			defer osx.MustSetenv("IPTABLES_SAVE_EXIT", tt.iptablesSaveCode)()
 			defer osx.MustSetenv("IPTABLES_EXIT", tt.iptablesCode)()
+
+			defer osx.MustSetenv("IP6TABLES_SAVE_EXIT", tt.iptablesSaveCode6)()
+			defer osx.MustSetenv("IP6TABLES_EXIT", tt.iptablesCode6)()
 
 			if err := r.Start("1234", "eth0"); (err != nil) != tt.wantErr {
 				t.Errorf("IPManager.Start() error = %v, wantErr %v", err, tt.wantErr)
@@ -42,28 +61,30 @@ func TestIPManager_Start(t *testing.T) {
 }
 
 func TestIPManager_Stop(t *testing.T) {
-	iptablesRestore = "./testdata/iptables-restore"
+	ip4tablesRestore = "./testdata/iptables-restore"
+	ip6tablesRestore = "./testdata/iptables-restore"
 
 	tests := []struct {
 		name        string
-		origRules   []byte
+		origRules4  []byte
+		origRules6  []byte
 		restoreExit string
 		wantErr     bool
 	}{
 		{
 			name:        "success",
 			restoreExit: "0",
-			origRules:   []byte("sample-input-message"),
+			origRules4:  []byte("sample-input-message"),
+			origRules6:  []byte(""),
 		},
 		{
-			name:      "failure-to-restore-empty-rules",
-			origRules: nil,
-			wantErr:   true,
+			name:    "failure-to-restore-empty-rules",
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r := &IPManager{origRules: tt.origRules}
+			r := &IPManager{origRules4: tt.origRules4, origRules6: tt.origRules6}
 			defer osx.MustSetenv("IPTABLES_RESTORE_EXIT", tt.restoreExit)()
 
 			b, err := r.Stop()

--- a/address/testdata/ip6tables
+++ b/address/testdata/ip6tables
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-exit ${IPTABLES_EXIT:-1}
+exit ${IP6TABLES_EXIT:-1}

--- a/address/testdata/ip6tables-save
+++ b/address/testdata/ip6tables-save
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exit ${IP6TABLES_SAVE_EXIT:-1}

--- a/cmd/envelope/main_test.go
+++ b/cmd/envelope/main_test.go
@@ -39,6 +39,9 @@ func Test_main(t *testing.T) {
 	flag.Set("address.iptables", "../../address/testdata/iptables")
 	flag.Set("address.iptables-save", "../../address/testdata/iptables-save")
 	flag.Set("address.iptables-restore", "../../address/testdata/iptables-restore")
+	flag.Set("address.ip6tables", "../../address/testdata/ip6tables")
+	flag.Set("address.ip6tables-save", "../../address/testdata/ip6tables-save")
+	flag.Set("address.ip6tables-restore", "../../address/testdata/iptables-restore")
 
 	// Load fake public verify key.
 	insecurePublicTestKey := []byte(`{"use":"sig","kty":"EC","kid":"112","crv":"P-256","alg":"ES256",` +
@@ -51,7 +54,9 @@ func Test_main(t *testing.T) {
 	verifyKeys = flagx.FileBytesArray{}
 	verifyKeys.Set(f.Name())
 	defer osx.MustSetenv("IPTABLES_EXIT", "0")()
+	defer osx.MustSetenv("IP6TABLES_EXIT", "0")()
 	defer osx.MustSetenv("IPTABLES_SAVE_EXIT", "0")()
+	defer osx.MustSetenv("IP6TABLES_SAVE_EXIT", "0")()
 
 	// Simulate unencrypted server.
 	listenAddr = ":0"


### PR DESCRIPTION
This change restores dual stack support to the access envelope.

As long as clients try available IPs for a hostname, then the same protocol used to open the envelope will be available to connect to the service.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/access/23)
<!-- Reviewable:end -->
