### PR TITLE
Add explicit override timeout flag to envelope

### DIFF
--- a/cmd/envelope/main.go
+++ b/cmd/envelope/main.go
@@ -37,6 +37,7 @@ var (
 	requireTokens bool
 	subject       string
 	manageDevice  string
+	timeout       time.Duration
 	tcpNetwork    = flagx.Enum{
 		Options: []string{"tcp", "tcp4", "tcp6"},
 		Value:   "tcp",
@@ -53,6 +54,7 @@ func init() {
 	flag.StringVar(&machine, "envelope.machine", "", "The machine name to expect in access token claims")
 	flag.StringVar(&subject, "envelope.subject", "", "The subject (service name) expected in access token claims")
 	flag.StringVar(&manageDevice, "envelope.device", "eth0", "The public network interface device name that the envelope manages")
+	flag.DurationVar(&timeout, "timeout", time.Minute, "Complete request within timeout. Overrides valid token expiration")
 	flagx.EnableAdvancedFlags() // Enable access to -httpx.tcp-network
 }
 
@@ -146,9 +148,12 @@ func (env *envelopeHandler) getDeadline(cl *jwt.Claims) (time.Time, error) {
 		return time.Time{}, fmt.Errorf("missing claim when tokens required")
 	}
 
+	// Calculate the earliest the deadline could be.
+	minDeadline := time.Now().Add(timeout)
+
 	if cl == nil {
 		// This could happen if tokens are not required.
-		return time.Now().Add(time.Minute), nil
+		return minDeadline, nil
 	}
 
 	if cl.Subject != env.subject {
@@ -161,6 +166,11 @@ func (env *envelopeHandler) getDeadline(cl *jwt.Claims) (time.Time, error) {
 	if deadline.Before(time.Now()) {
 		logx.Debug.Println("already past expiration")
 		return time.Time{}, fmt.Errorf("already past claim expiration")
+	}
+
+	// Give the service enough time to run by choosing the later deadline.
+	if deadline.Before(minDeadline) {
+		deadline = minDeadline
 	}
 	return deadline, nil
 }

--- a/cmd/envelope/main.go
+++ b/cmd/envelope/main.go
@@ -168,7 +168,8 @@ func (env *envelopeHandler) getDeadline(cl *jwt.Claims) (time.Time, error) {
 		return time.Time{}, fmt.Errorf("already past claim expiration")
 	}
 
-	// Give the service enough time to run by choosing the later deadline.
+	// If the token deadline is even earlier than the minDeadline, reset to the
+	// later time.
 	if deadline.Before(minDeadline) {
 		deadline = minDeadline
 	}


### PR DESCRIPTION
This change adds a new flag to the access envelope that allows a `-timeout` flag to override the token expiration time. This means, that the timeout given on the command line will override the token expiration if it is later. Between the token and the `-timeout` value, the later deadline will always apply.

NOTE: this deadline only applies when the client keeps the access envelope websocket connection open. Once the client closes the connection, any IP grants are immediately revoked.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/access/24)
<!-- Reviewable:end -->
