### PR TITLE
Update metric names to use package name

### DIFF
--- a/controller/token.go
+++ b/controller/token.go
@@ -16,8 +16,8 @@ import (
 var (
 	tokenAccessRequests = promauto.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "ndt_access_token_requests_total",
-			Help: "Total number of NDT requests handled by the access tokencontroller.",
+			Name: "controller_access_token_requests_total",
+			Help: "Total number of requests handled by the access tokencontroller.",
 		},
 		[]string{"path", "request", "reason"},
 	)

--- a/controller/tx.go
+++ b/controller/tx.go
@@ -23,7 +23,7 @@ var (
 	maxRate          uint64
 	txAccessRequests = promauto.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "ndt_access_txcontroller_requests_total",
+			Name: "controller_access_txcontroller_requests_total",
 			Help: "Total number of requests handled by the access txcontroller.",
 		},
 		[]string{"request", "protocol"},


### PR DESCRIPTION
While realizing that the access envelope for wehe should include the same metric updates as we want for ndt-server using access tokens, I realized that the metric names in the controller package use "ndt_" when they should be generic. This is a legacy of these packages beginning in the ndt-server repo and being migrated here to be generally useful. However, this change corrects the names to also be general to other users.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/access/28)
<!-- Reviewable:end -->
