### PR TITLE
Allow access controller users to register label paths

### DIFF
--- a/cmd/envelope/main.go
+++ b/cmd/envelope/main.go
@@ -247,6 +247,7 @@ func main() {
 	ac := alice.New(logger).Extend(ctl)
 	mux := http.NewServeMux()
 	mux.HandleFunc("/v0/envelope/access", env.AllowRequest)
+	controller.AllowPathLabel("/v0/envelope/access")
 	srv := &http.Server{
 		Addr:    listenAddr,
 		Handler: ac.Then(mux),

--- a/controller/token_test.go
+++ b/controller/token_test.go
@@ -155,6 +155,7 @@ func TestTokenController_Limit(t *testing.T) {
 				visited = true
 				isMonitoring = IsMonitoring(GetClaim(req.Context()))
 			})
+			AllowPathLabel("/")
 			req := httptest.NewRequest(http.MethodGet, "/", nil)
 			req.Form = url.Values{}
 			if tt.token != "" {


### PR DESCRIPTION
This change allows users of the access controller package to register paths that should be used in prometheus metric labels for the `controller_access_token_requests_total` metric. All unregistered paths will be labeled as "unknown". This would replicate current behavior.

This change will allow us to account for access token behavior between different versions of ndt, e.g. ndt5 and ndt7.

Alternatives considered:
* It is unfortunate that callers must be updated to register all paths. It is unfortunate that the path must be specified twice rather than discovered.
* I considered using a regexp to match requests, but that is unnecessarily complex for a small number of static paths.
* I considered a flag that allowed specifying the paths, but this externalizes configuration that need not be a flag.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/access/29)
<!-- Reviewable:end -->
