### PR TITLE
Prevent panics during parallel connections

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-- 1.13
+- 1.15
 
 install:
 - go get -v -t ./...

--- a/address/granter.go
+++ b/address/granter.go
@@ -76,11 +76,11 @@ func ipTable(action string, ip net.IP) pipe.Pipe {
 	// Parameters are the same for IPv4 and IPv6 addresses, but the command is not.
 	cmd, subnet := cmdForIP(ip)
 	return pipe.Script(action,
-		pipe.Exec(cmd, "--"+action+"=INPUT", "--source="+ip.String()+subnet, "--jump=ACCEPT"),
+		pipe.Exec(cmd, "--"+action+"=INPUT", "--source="+ip.String()+subnet, "--jump=ACCEPT", "--wait"),
 		// Unconditionally allow connections from "standard HTTP ports" to allow connections
 		// from "optimizing proxies" which may use different source addresses.
-		pipe.Exec(cmd, "--"+action+"=INPUT", "--protocol=tcp", "--dport=80", "--jump=ACCEPT"),
-		pipe.Exec(cmd, "--"+action+"=INPUT", "--protocol=tcp", "--dport=443", "--jump=ACCEPT"),
+		pipe.Exec(cmd, "--"+action+"=INPUT", "--protocol=tcp", "--dport=80", "--jump=ACCEPT", "--wait"),
+		pipe.Exec(cmd, "--"+action+"=INPUT", "--protocol=tcp", "--dport=443", "--jump=ACCEPT", "--wait"),
 	)
 }
 

--- a/address/granter.go
+++ b/address/granter.go
@@ -76,11 +76,11 @@ func ipTable(action string, ip net.IP) pipe.Pipe {
 	// Parameters are the same for IPv4 and IPv6 addresses, but the command is not.
 	cmd, subnet := cmdForIP(ip)
 	return pipe.Script(action,
-		pipe.Exec(cmd, "--"+action+"=INPUT", "--source="+ip.String()+subnet, "--jump=ACCEPT", "--wait"),
+		pipe.Exec(cmd, "--"+action+"=INPUT", "--source="+ip.String()+subnet, "--jump=ACCEPT", "--wait=1"),
 		// Unconditionally allow connections from "standard HTTP ports" to allow connections
 		// from "optimizing proxies" which may use different source addresses.
-		pipe.Exec(cmd, "--"+action+"=INPUT", "--protocol=tcp", "--dport=80", "--jump=ACCEPT", "--wait"),
-		pipe.Exec(cmd, "--"+action+"=INPUT", "--protocol=tcp", "--dport=443", "--jump=ACCEPT", "--wait"),
+		pipe.Exec(cmd, "--"+action+"=INPUT", "--protocol=tcp", "--dport=80", "--jump=ACCEPT", "--wait=1"),
+		pipe.Exec(cmd, "--"+action+"=INPUT", "--protocol=tcp", "--dport=443", "--jump=ACCEPT", "--wait=1"),
 	)
 }
 

--- a/address/setup.go
+++ b/address/setup.go
@@ -89,20 +89,20 @@ func start(iptablesSave, iptables, port, device, protocol string) ([]byte, error
 	afterCommands := []pipe.Pipe{
 		pipe.Exec(iptables,
 			// Allow protocol specific ICMP traffic.
-			"--append=INPUT", "--protocol="+protocol, "--jump=ACCEPT"),
+			"--append=INPUT", "--protocol="+protocol, "--jump=ACCEPT", "--wait"),
 		pipe.Exec(iptables,
 			// Envelope service itself.
-			"--append=INPUT", "--protocol=tcp", "--dport="+port, "--jump=ACCEPT"),
+			"--append=INPUT", "--protocol=tcp", "--dport="+port, "--jump=ACCEPT", "--wait"),
 		pipe.Exec(iptables,
 			// DNS
-			"--append=INPUT", "--protocol=udp", "--dport=53", "--jump=ACCEPT"),
+			"--append=INPUT", "--protocol=udp", "--dport=53", "--jump=ACCEPT", "--wait"),
 		pipe.Exec(iptables,
 			// Established connections.
-			"--append=INPUT", "--match=conntrack", "--ctstate=ESTABLISHED,RELATED", "--jump=ACCEPT"),
+			"--append=INPUT", "--match=conntrack", "--ctstate=ESTABLISHED,RELATED", "--jump=ACCEPT", "--wait"),
 
 		// The last rule "rejects" packets, to send clients a signal that their
 		// connection was refused rather than silently dropped.
-		pipe.Exec(iptables, "--append=INPUT", "--jump=REJECT"),
+		pipe.Exec(iptables, "--append=INPUT", "--jump=REJECT", "--wait"),
 	}
 
 	commands := append(startCommands, afterCommands...)

--- a/address/setup.go
+++ b/address/setup.go
@@ -89,20 +89,20 @@ func start(iptablesSave, iptables, port, device, protocol string) ([]byte, error
 	afterCommands := []pipe.Pipe{
 		pipe.Exec(iptables,
 			// Allow protocol specific ICMP traffic.
-			"--append=INPUT", "--protocol="+protocol, "--jump=ACCEPT", "--wait"),
+			"--append=INPUT", "--protocol="+protocol, "--jump=ACCEPT", "--wait=1"),
 		pipe.Exec(iptables,
 			// Envelope service itself.
-			"--append=INPUT", "--protocol=tcp", "--dport="+port, "--jump=ACCEPT", "--wait"),
+			"--append=INPUT", "--protocol=tcp", "--dport="+port, "--jump=ACCEPT", "--wait=1"),
 		pipe.Exec(iptables,
 			// DNS
-			"--append=INPUT", "--protocol=udp", "--dport=53", "--jump=ACCEPT", "--wait"),
+			"--append=INPUT", "--protocol=udp", "--dport=53", "--jump=ACCEPT", "--wait=1"),
 		pipe.Exec(iptables,
 			// Established connections.
-			"--append=INPUT", "--match=conntrack", "--ctstate=ESTABLISHED,RELATED", "--jump=ACCEPT", "--wait"),
+			"--append=INPUT", "--match=conntrack", "--ctstate=ESTABLISHED,RELATED", "--jump=ACCEPT", "--wait=1"),
 
 		// The last rule "rejects" packets, to send clients a signal that their
 		// connection was refused rather than silently dropped.
-		pipe.Exec(iptables, "--append=INPUT", "--jump=REJECT", "--wait"),
+		pipe.Exec(iptables, "--append=INPUT", "--jump=REJECT", "--wait=1"),
 	}
 
 	commands := append(startCommands, afterCommands...)


### PR DESCRIPTION
On the first attempt to increase the envelope.max-clients for Wehe, we observed multiple panics. The root cause is that iptables locks the `/run/xtables.lock` file during iptables operations. The `--wait` flag asks the iptables command to wait up to 1sec for the lock to succeed before exit with error.

This change also completes the panic processing and unit test coverage for that handling.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/access/33)
<!-- Reviewable:end -->
