### PR TITLE
Always accept monitoring claims

### DIFF
--- a/cmd/envelope/main.go
+++ b/cmd/envelope/main.go
@@ -180,7 +180,7 @@ func (env *envelopeHandler) getDeadline(cl *jwt.Claims) (time.Time, error) {
 		return minDeadline, nil
 	}
 
-	if cl.Subject != env.subject {
+	if cl.Subject != env.subject && !controller.IsMonitoring(cl) {
 		logx.Debug.Println("wrong subject claim")
 		return time.Time{}, fmt.Errorf("wrong claim subject")
 	}

--- a/cmd/envelope/main_test.go
+++ b/cmd/envelope/main_test.go
@@ -222,6 +222,15 @@ func Test_envelopeHandler_AllowRequest_Websocket(t *testing.T) {
 			sleep: 2 * time.Second, // Force delay to create timeout.
 		},
 		{
+			name: "success-claim-subject-is-monitoring",
+			code: http.StatusSwitchingProtocols,
+			claim: &jwt.Claims{
+				Issuer:  "locate",
+				Subject: "monitoring",
+				Expiry:  jwt.NewNumericDate(time.Now().Add(time.Minute * 5)),
+			},
+		},
+		{
 			name: "error-revoke-ip-failure-panic",
 			code: http.StatusSwitchingProtocols, // websocket is setup successfully.
 			claim: &jwt.Claims{


### PR DESCRIPTION
Currently, the access envelope will reject claims with a subject of "monitoring". This PR causes it to accept those claims. The impetus for this change is to enable the wehe-cmdline client to be used for e2e testing via the script-exporter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/access/34)
<!-- Reviewable:end -->
