### PR TITLE
Update to go1.18

### DIFF
--- a/Dockerfile.envelope
+++ b/Dockerfile.envelope
@@ -1,8 +1,8 @@
 # Built the command using a golang base image.
-FROM golang:1.18-alpine3.14 AS build
-RUN apk add git
+FROM golang:1.18 AS build
 ADD . /go/src/github.com/m-lab/access
-RUN go get -v github.com/m-lab/access/cmd/envelope
+WORKDIR /go/src/github.com/m-lab/access
+RUN CGO_ENABLED=0 go install -v ./cmd/envelope
 
 # Now copy the resulting command into the minimal base image.
 FROM alpine:3.14

--- a/Dockerfile.envelope
+++ b/Dockerfile.envelope
@@ -1,11 +1,11 @@
 # Built the command using a golang base image.
-FROM golang:1.14.4-alpine3.12 AS build
+FROM golang:1.18-alpine3.14 AS build
 RUN apk add git
 ADD . /go/src/github.com/m-lab/access
 RUN go get -v github.com/m-lab/access/cmd/envelope
 
 # Now copy the resulting command into the minimal base image.
-FROM alpine:3.12
+FROM alpine:3.14
 COPY --from=build /go/bin/envelope /
 WORKDIR /
 RUN apk add --no-cache iptables ip6tables ca-certificates && update-ca-certificates


### PR DESCRIPTION
This change updates the Dockerfile.envelope to use go1.18.

Part of:
* https://github.com/m-lab/dev-tracker/issues/735

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/access/37)
<!-- Reviewable:end -->
