### PR TITLE
Add JWKS func to token package and upgrade to gojose v4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 language: go
 
 go:
-- 1.20
+  - "1.22"
 
 install:
-- go get -v -t ./...
-- go install github.com/mattn/goveralls@latest
+  - go get -v -t ./...
+  - go install github.com/mattn/goveralls@latest
 
 script:
-- go vet ./...
-- go test ./... -v -cover=1 -coverprofile=_c.cov
-- go test ./... -race
-- $GOPATH/bin/goveralls -service=travis-ci -coverprofile=_c.cov
+  - go vet ./...
+  - go test ./... -v -cover=1 -coverprofile=_c.cov
+  - go test ./... -race
+  - $GOPATH/bin/goveralls -service=travis-ci -coverprofile=_c.cov

--- a/cmd/envelope/main.go
+++ b/cmd/envelope/main.go
@@ -11,12 +11,12 @@ import (
 	"os"
 	"time"
 
+	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/websocket"
 	"github.com/justinas/alice"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"gopkg.in/square/go-jose.v2/jwt"
 
 	"github.com/m-lab/access/address"
 	"github.com/m-lab/access/chanio"

--- a/cmd/envelope/main_test.go
+++ b/cmd/envelope/main_test.go
@@ -16,10 +16,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/websocket"
 	"github.com/justinas/alice"
-	"gopkg.in/square/go-jose.v2/jwt"
 
 	"github.com/m-lab/access/address"
 	"github.com/m-lab/access/controller"

--- a/cmd/example-signer/main.go
+++ b/cmd/example-signer/main.go
@@ -5,8 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"gopkg.in/square/go-jose.v2/jwt"
-
+	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/m-lab/access/token"
 	"github.com/m-lab/go/flagx"
 	"github.com/m-lab/go/pretty"

--- a/controller/control.go
+++ b/controller/control.go
@@ -8,8 +8,8 @@ import (
 	"net/http"
 
 	// Alice package provides a light weight way to chain HTTP middleware functions.
+	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/justinas/alice"
-	"gopkg.in/square/go-jose.v2/jwt"
 )
 
 // TODO: replace with constants from the locate service repository.
@@ -74,8 +74,8 @@ func Setup(ctx context.Context, v Verifier, tokenRequired bool, machine string, 
 
 	// If the verifier is not nil, include the token limit.
 	exp := jwt.Expected{
-		Issuer:   locateIssuer,
-		Audience: jwt.Audience{machine},
+		Issuer:      locateIssuer,
+		AnyAudience: jwt.Audience{machine},
 	}
 	token, err := NewTokenController(v, tokenRequired, exp, tkEnf)
 	if err == nil {

--- a/controller/control_test.go
+++ b/controller/control_test.go
@@ -6,8 +6,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/justinas/alice"
-	"gopkg.in/square/go-jose.v2/jwt"
 )
 
 func TestGetClaim(t *testing.T) {

--- a/controller/token.go
+++ b/controller/token.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"gopkg.in/square/go-jose.v2/jwt"
 )
 
 var (
@@ -70,7 +70,7 @@ func NewTokenController(verifier Verifier, required bool, exp jwt.Expected, enfo
 	if exp.Issuer == "" {
 		return nil, jwt.ErrInvalidIssuer
 	}
-	if exp.Audience == nil || exp.Audience.Contains("") {
+	if exp.AnyAudience == nil || exp.AnyAudience.Contains("") {
 		return nil, jwt.ErrInvalidAudience
 	}
 	return &TokenController{

--- a/controller/token_test.go
+++ b/controller/token_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"gopkg.in/square/go-jose.v2/jwt"
+	"github.com/go-jose/go-jose/v4/jwt"
 )
 
 type fakeVerifier struct {
@@ -174,8 +174,8 @@ func TestTokenController_Limit(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			exp := jwt.Expected{
-				Issuer:   tt.issuer,
-				Audience: jwt.Audience{tt.machine},
+				Issuer:      tt.issuer,
+				AnyAudience: jwt.Audience{tt.machine},
 			}
 			token, err := NewTokenController(tt.verifier, tt.required, exp, tt.expected)
 			if (err != nil) != tt.wantErr {

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,11 @@
 module github.com/m-lab/access
 
-go 1.20
+go 1.22
+
+toolchain go1.22.2
 
 require (
+	github.com/go-jose/go-jose/v4 v4.0.5
 	github.com/go-test/deep v1.0.8
 	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/websocket v1.5.0
@@ -13,7 +16,6 @@ require (
 	github.com/prometheus/procfs v0.8.0
 	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4
 	gopkg.in/m-lab/pipe.v3 v3.0.0-20180108231244-604e84f43ee0
-	gopkg.in/square/go-jose.v2 v2.6.0
 )
 
 require (
@@ -26,7 +28,7 @@ require (
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
-	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 // indirect
-	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
+	golang.org/x/crypto v0.32.0 // indirect
+	golang.org/x/sys v0.29.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,8 @@ github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSw
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
+github.com/go-jose/go-jose/v4 v4.0.5 h1:M6T8+mKZl/+fNNuFHvGIzDz7BTLQPIounk/b9dw3AaE=
+github.com/go-jose/go-jose/v4 v4.0.5/go.mod h1:s3P1lRrkT8igV8D9OjyL4WRyHvjB6a4JSllnOrmmBOA=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=
@@ -107,6 +109,7 @@ github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaS
 github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/gomodule/redigo v1.8.8 h1:f6cXq6RRfiyrOJEV7p3JhLDlmawGBVBBP1MggY8Mo4E=
+github.com/gomodule/redigo v1.8.8/go.mod h1:7ArFNvsTjH8GMMzB4uy1snslv2BwmginuMs06a1uzZE=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
@@ -118,7 +121,8 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
@@ -151,6 +155,7 @@ github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8
 github.com/justinas/alice v1.2.0 h1:+MHSA/vccVCF4Uq37S42jwlkvI2Xzl7zTPCN5BnZNVo=
 github.com/justinas/alice v1.2.0/go.mod h1:fN5HRH/reO/zrUflLfTN43t3vXvKzvZIENsNEe7i7qA=
 github.com/kabukky/httpscerts v0.0.0-20150320125433-617593d7dcb3 h1:Iy7Ifq2ysilWU4QlCx/97OoI4xT1IV7i8byT/EyIT/M=
+github.com/kabukky/httpscerts v0.0.0-20150320125433-617593d7dcb3/go.mod h1:BYpt4ufZiIGv2nXn4gMxnfKV306n3mWXgNu/d2TqdTU=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
@@ -215,8 +220,9 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -230,8 +236,9 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.32.0 h1:euUpcYgM8WcP71gNpTqQCn6rC2t6ULUPiOzfWaXVVfc=
+golang.org/x/crypto v0.32.0/go.mod h1:ZnnJkOaASj8g0AjIduWNlq2NRxL0PlBrbKVyZ6V/Ugc=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -349,8 +356,8 @@ golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
-golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=
+golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -492,15 +499,14 @@ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/m-lab/pipe.v3 v3.0.0-20180108231244-604e84f43ee0 h1:Hnr2d6Buku0hkEfmxBcVb71BWJexaGxcFAht2wZ/fGM=
 gopkg.in/m-lab/pipe.v3 v3.0.0-20180108231244-604e84f43ee0/go.mod h1:+hOW3sZYs8MQA/xKbuKxJ6rlM7CThhtHodpCaOzVWcE=
-gopkg.in/square/go-jose.v2 v2.6.0 h1:NGk74WTnPKBNUhNzQX7PYcTLUjoq7mzKk2OKbvwk2iI=
-gopkg.in/square/go-jose.v2 v2.6.0/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/token/jwt.go
+++ b/token/jwt.go
@@ -1,3 +1,5 @@
+// Package token provides support for parsing JSON Web Keys (JWK),
+// creating signed JSON Web Tokens (JWT), and verifying JWT signatures.
 package token
 
 import (
@@ -8,15 +10,20 @@ import (
 	"github.com/go-jose/go-jose/v4/jwt"
 )
 
+// ErrKeyIDNotFound is returned when trying to verify a token when there are no
+// corresponding key IDs matching the token header.
 var ErrKeyIDNotFound = errors.New("Key ID not found for given token header")
+
+// ErrDuplicateKeyID is returned when initializing a verifier with multiple keys
+// with the same KeyID. KeyIDs should be unique.
 var ErrDuplicateKeyID = errors.New("Duplicate KeyID found")
 
-// Verifier is a JWT verifier.
+// Verifier is a JWT verifier. Requires a public JWK.
 type Verifier struct {
 	keys map[string]*jose.JSONWebKey
 }
 
-// Signer is a JWT signer.
+// Signer is a JWT signer. Requires a private JWK.
 type Signer struct {
 	jwt.Builder
 	key *jose.JSONWebKey

--- a/token/jwt.go
+++ b/token/jwt.go
@@ -76,7 +76,9 @@ func NewVerifier(keys ...[]byte) (*Verifier, error) {
 	}, nil
 }
 
-// Claims returns the claims from a token.
+// Claims extracts the claims from a signed token, but does not
+// validate them against any expected claims. Useful for extracting
+// only the claims object.
 func (k *Verifier) Claims(token string) (*jwt.Claims, error) {
 	tok, err := jwt.ParseSigned(token, []jose.SignatureAlgorithm{
 		jose.EdDSA,

--- a/token/jwt.go
+++ b/token/jwt.go
@@ -1,58 +1,46 @@
-// Package token provides support for parsing JSON Web Keys (JWK),
-// creating signed JSON Web Tokens (JWT), and verifying JWT signatures.
 package token
 
 import (
 	"errors"
 	"fmt"
 
-	jose "gopkg.in/square/go-jose.v2"
-	"gopkg.in/square/go-jose.v2/jwt"
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
 )
 
-// ErrKeyIDNotFound is returned when trying to verify a token when there are no
-// corresponding key IDs matching the token header.
 var ErrKeyIDNotFound = errors.New("Key ID not found for given token header")
-
-// ErrDuplicateKeyID is returned when initializing a verifier with multiple keys
-// with the same KeyID. KeyIDs should be unique.
 var ErrDuplicateKeyID = errors.New("Duplicate KeyID found")
 
-// Verifier supports operations on a public JWK.
 type Verifier struct {
 	keys map[string]*jose.JSONWebKey
 }
 
-// Signer supports operations on a private JWK.
 type Signer struct {
 	jwt.Builder
 }
 
-// NewSigner accepts a serialized, private JWK and creates a new Signer instance.
 func NewSigner(key []byte) (*Signer, error) {
 	priv, err := LoadJSONWebKey(key, false)
 	if err != nil {
 		return nil, err
 	}
-	alg := jose.SignatureAlgorithm(priv.Algorithm)
-	signer, err := jose.NewSigner(jose.SigningKey{Algorithm: alg, Key: priv}, nil)
+
+	opts := &jose.SignerOptions{}
+	signer, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.SignatureAlgorithm(priv.Algorithm), Key: priv}, opts)
+	if err != nil {
+		return nil, err
+	}
+
 	p := &Signer{
 		Builder: jwt.Signed(signer),
 	}
-	return p, err
+	return p, nil
 }
 
-// Sign generates a signed JWT in compact form.
 func (k *Signer) Sign(cl jwt.Claims) (string, error) {
-	// Create a builder for signed tokens, apply claims, and serialize.
-	return k.Builder.Claims(cl).CompactSerialize()
+	return k.Builder.Claims(cl).Serialize()
 }
 
-// NewVerifier accepts serialized, public JWKs and creates a new Verifier
-// instance. Caller may pass multiple verifier keys to recognize and support key
-// rotation of signer keys, or multiple issuers. When providing multiple keys
-// each must have a distinct "keyid". An error derived from ErrDuplicateKeyID is
-// returned when keys have the same keyid.
 func NewVerifier(keys ...[]byte) (*Verifier, error) {
 	pubKeys := map[string]*jose.JSONWebKey{}
 	for i := range keys {
@@ -70,45 +58,58 @@ func NewVerifier(keys ...[]byte) (*Verifier, error) {
 	}, nil
 }
 
-// Claims extracts the claims from a signed token, but does not
-// validate them against any expected claims. Useful for extracting
-// only the claims object.
 func (k *Verifier) Claims(token string) (*jwt.Claims, error) {
-	obj, err := jwt.ParseSigned(token)
+	tok, err := jwt.ParseSigned(token, []jose.SignatureAlgorithm{
+		jose.EdDSA,
+		jose.ES256,
+		jose.RS256,
+	})
 	if err != nil {
 		return nil, err
 	}
-	// NOTE: if ParseSigned returns without error, then we are guaranteed that
-	// at least one header is present. And, we will not support tokens with
-	// multiple signatures/headers.
-	keyID := obj.Headers[0].KeyID
+
+	headers := tok.Headers
+	if len(headers) == 0 {
+		return nil, errors.New("no headers found in token")
+	}
+
+	keyID := headers[0].KeyID
 	pub, found := k.keys[keyID]
 	if !found {
 		return nil, fmt.Errorf("%w: %s", ErrKeyIDNotFound, keyID)
 	}
-	// Claims validates the jwt signature before extracting the token claims.
+
 	cl := &jwt.Claims{}
-	err = obj.Claims(pub, cl)
+	err = tok.Claims(pub, cl)
 	if err != nil {
 		return nil, err
 	}
 	return cl, nil
 }
 
-// Verify checks the token signature and that the claims match the expected
-// config. Note: if validation of the expected claims fails, then Verify will
-// return the original token claims with the corresponding non-nil validation error.
 func (k *Verifier) Verify(token string, exp jwt.Expected) (*jwt.Claims, error) {
 	cl, err := k.Claims(token)
 	if err != nil {
 		return nil, err
 	}
-	// Verify that the expected claims satisfy the signed claims.
 	err = cl.Validate(exp)
 	return cl, err
 }
 
-// LoadJSONWebKey loads and validates the given JWK.
+// JWKS returns a JSON Web Key Set containing all public keys in the Verifier.
+func (k *Verifier) JWKS() jose.JSONWebKeySet {
+	jwks := jose.JSONWebKeySet{
+		Keys: make([]jose.JSONWebKey, 0, len(k.keys)),
+	}
+
+	for _, key := range k.keys {
+		// Ensure we only add public keys to the JWKS
+		jwks.Keys = append(jwks.Keys, key.Public())
+	}
+
+	return jwks
+}
+
 func LoadJSONWebKey(json []byte, isPublic bool) (*jose.JSONWebKey, error) {
 	var jwk jose.JSONWebKey
 	err := jwk.UnmarshalJSON(json)

--- a/token/jwt.go
+++ b/token/jwt.go
@@ -22,7 +22,7 @@ type Signer struct {
 	key *jose.JSONWebKey
 }
 
-// NewSigner creates a new Signer from the given private key.
+// NewSigner accepts a serialized, private JWK and creates a new Signer instance.
 func NewSigner(key []byte) (*Signer, error) {
 	priv, err := LoadJSONWebKey(key, false)
 	if err != nil {
@@ -54,7 +54,11 @@ func (s *Signer) JWKS() jose.JSONWebKeySet {
 	}
 }
 
-// NewVerifier creates a new Verifier from the given public keys.
+// NewVerifier accepts serialized, public JWKs and creates a new Verifier
+// instance. Caller may pass multiple verifier keys to recognize and support key
+// rotation of signer keys, or multiple issuers. When providing multiple keys
+// each must have a distinct "keyid". An error derived from ErrDuplicateKeyID is
+// returned when keys have the same keyid.
 func NewVerifier(keys ...[]byte) (*Verifier, error) {
 	pubKeys := map[string]*jose.JSONWebKey{}
 	for i := range keys {

--- a/token/jwt.go
+++ b/token/jwt.go
@@ -11,14 +11,17 @@ import (
 var ErrKeyIDNotFound = errors.New("Key ID not found for given token header")
 var ErrDuplicateKeyID = errors.New("Duplicate KeyID found")
 
+// Verifier is a JWT verifier.
 type Verifier struct {
 	keys map[string]*jose.JSONWebKey
 }
 
+// Signer is a JWT signer.
 type Signer struct {
 	jwt.Builder
 }
 
+// NewSigner creates a new Signer from the given private key.
 func NewSigner(key []byte) (*Signer, error) {
 	priv, err := LoadJSONWebKey(key, false)
 	if err != nil {
@@ -37,10 +40,12 @@ func NewSigner(key []byte) (*Signer, error) {
 	return p, nil
 }
 
+// Sign signs the given claims and returns the serialized token.
 func (k *Signer) Sign(cl jwt.Claims) (string, error) {
 	return k.Builder.Claims(cl).Serialize()
 }
 
+// NewVerifier creates a new Verifier from the given public keys.
 func NewVerifier(keys ...[]byte) (*Verifier, error) {
 	pubKeys := map[string]*jose.JSONWebKey{}
 	for i := range keys {
@@ -58,6 +63,7 @@ func NewVerifier(keys ...[]byte) (*Verifier, error) {
 	}, nil
 }
 
+// Claims returns the claims from a token.
 func (k *Verifier) Claims(token string) (*jwt.Claims, error) {
 	tok, err := jwt.ParseSigned(token, []jose.SignatureAlgorithm{
 		jose.EdDSA,
@@ -87,6 +93,7 @@ func (k *Verifier) Claims(token string) (*jwt.Claims, error) {
 	return cl, nil
 }
 
+// Verify verifies the given token and returns its claims.
 func (k *Verifier) Verify(token string, exp jwt.Expected) (*jwt.Claims, error) {
 	cl, err := k.Claims(token)
 	if err != nil {
@@ -110,6 +117,7 @@ func (k *Verifier) JWKS() jose.JSONWebKeySet {
 	return jwks
 }
 
+// LoadJSONWebKey loads a JSON Web Key from the given JSON data.
 func LoadJSONWebKey(json []byte, isPublic bool) (*jose.JSONWebKey, error) {
 	var jwk jose.JSONWebKey
 	err := jwk.UnmarshalJSON(json)


### PR DESCRIPTION
Add a function to generate a JSON Web Key Set to `Signer()`. This allows to easily implement the common pattern where a JWT signer exposes an endpoint (e.g. `$HOSTNAME/.well-known/jwks.json`) that provides the public keys to verify its own signed tokens.

While I was there, I updated the JWT library from v1 to v4.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/access/40)
<!-- Reviewable:end -->
