### PR TITLE
feat: support caller-defined custom JWT claims

### DIFF
--- a/controller/claims.go
+++ b/controller/claims.go
@@ -2,31 +2,23 @@ package controller
 
 import "context"
 
-// IntegrationClaims contains M-Lab integration-specific JWT claims.
-// These identify which integrator and API key were used for a request.
-type IntegrationClaims struct {
-	IntegrationID string `json:"int_id,omitempty"`
-	KeyID         string `json:"key_id,omitempty"`
+type customClaimContextKeyType struct{}
+
+var customClaimContextKey = customClaimContextKeyType{}
+
+// SetCustomClaim returns a derived context carrying the given caller-defined
+// claim value. The value is typically a pointer to a struct populated by
+// Verifier.Verify via its variadic destination argument.
+func SetCustomClaim(ctx context.Context, v any) context.Context {
+	return context.WithValue(ctx, customClaimContextKey, v)
 }
 
-type integrationClaimsContextKeyType struct{}
-
-var integrationClaimsContextKey = integrationClaimsContextKeyType{}
-
-// SetIntegrationClaims returns a derived context with the given integration claims.
-func SetIntegrationClaims(ctx context.Context, ic *IntegrationClaims) context.Context {
-	return context.WithValue(ctx, integrationClaimsContextKey, ic)
-}
-
-// GetIntegrationClaims extracts integration claims from the given context.
-// Returns nil if no integration claims are present.
-func GetIntegrationClaims(ctx context.Context) *IntegrationClaims {
+// GetCustomClaim returns the caller-defined claim value previously stored via
+// SetCustomClaim, or nil if none is present. Callers are expected to type
+// assert the returned value to their own claim type.
+func GetCustomClaim(ctx context.Context) any {
 	if ctx == nil {
 		return nil
 	}
-	value := ctx.Value(integrationClaimsContextKey)
-	if value == nil {
-		return nil
-	}
-	return value.(*IntegrationClaims)
+	return ctx.Value(customClaimContextKey)
 }

--- a/controller/claims.go
+++ b/controller/claims.go
@@ -1,0 +1,32 @@
+package controller
+
+import "context"
+
+// IntegrationClaims contains M-Lab integration-specific JWT claims.
+// These identify which integrator and API key were used for a request.
+type IntegrationClaims struct {
+	IntegrationID string `json:"int_id,omitempty"`
+	KeyID         string `json:"key_id,omitempty"`
+}
+
+type integrationClaimsContextKeyType struct{}
+
+var integrationClaimsContextKey = integrationClaimsContextKeyType{}
+
+// SetIntegrationClaims returns a derived context with the given integration claims.
+func SetIntegrationClaims(ctx context.Context, ic *IntegrationClaims) context.Context {
+	return context.WithValue(ctx, integrationClaimsContextKey, ic)
+}
+
+// GetIntegrationClaims extracts integration claims from the given context.
+// Returns nil if no integration claims are present.
+func GetIntegrationClaims(ctx context.Context) *IntegrationClaims {
+	if ctx == nil {
+		return nil
+	}
+	value := ctx.Value(integrationClaimsContextKey)
+	if value == nil {
+		return nil
+	}
+	return value.(*IntegrationClaims)
+}

--- a/controller/claims.go
+++ b/controller/claims.go
@@ -17,8 +17,5 @@ func SetCustomClaim(ctx context.Context, v any) context.Context {
 // SetCustomClaim, or nil if none is present. Callers are expected to type
 // assert the returned value to their own claim type.
 func GetCustomClaim(ctx context.Context) any {
-	if ctx == nil {
-		return nil
-	}
 	return ctx.Value(customClaimContextKey)
 }

--- a/controller/claims_test.go
+++ b/controller/claims_test.go
@@ -7,11 +7,15 @@ import (
 	"github.com/go-test/deep"
 )
 
-func TestGetIntegrationClaims(t *testing.T) {
+func TestGetCustomClaim(t *testing.T) {
+	type custom struct {
+		Foo string
+	}
+	val := &custom{Foo: "bar"}
 	tests := []struct {
 		name string
 		ctx  context.Context
-		want *IntegrationClaims
+		want any
 	}{
 		{
 			name: "nil-context",
@@ -19,27 +23,21 @@ func TestGetIntegrationClaims(t *testing.T) {
 			want: nil,
 		},
 		{
-			name: "no-claims-in-context",
+			name: "no-claim-in-context",
 			ctx:  context.Background(),
 			want: nil,
 		},
 		{
-			name: "with-integration-claims",
-			ctx: SetIntegrationClaims(context.Background(), &IntegrationClaims{
-				IntegrationID: "test-int",
-				KeyID:         "ki_test",
-			}),
-			want: &IntegrationClaims{
-				IntegrationID: "test-int",
-				KeyID:         "ki_test",
-			},
+			name: "with-custom-claim",
+			ctx:  SetCustomClaim(context.Background(), val),
+			want: val,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := GetIntegrationClaims(tt.ctx)
+			got := GetCustomClaim(tt.ctx)
 			if diff := deep.Equal(got, tt.want); diff != nil {
-				t.Errorf("GetIntegrationClaims() mismatch: %v", diff)
+				t.Errorf("GetCustomClaim() mismatch: %v", diff)
 			}
 		})
 	}

--- a/controller/claims_test.go
+++ b/controller/claims_test.go
@@ -1,0 +1,46 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-test/deep"
+)
+
+func TestGetIntegrationClaims(t *testing.T) {
+	tests := []struct {
+		name string
+		ctx  context.Context
+		want *IntegrationClaims
+	}{
+		{
+			name: "nil-context",
+			ctx:  nil,
+			want: nil,
+		},
+		{
+			name: "no-claims-in-context",
+			ctx:  context.Background(),
+			want: nil,
+		},
+		{
+			name: "with-integration-claims",
+			ctx: SetIntegrationClaims(context.Background(), &IntegrationClaims{
+				IntegrationID: "test-int",
+				KeyID:         "ki_test",
+			}),
+			want: &IntegrationClaims{
+				IntegrationID: "test-int",
+				KeyID:         "ki_test",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetIntegrationClaims(tt.ctx)
+			if diff := deep.Equal(got, tt.want); diff != nil {
+				t.Errorf("GetIntegrationClaims() mismatch: %v", diff)
+			}
+		})
+	}
+}

--- a/controller/claims_test.go
+++ b/controller/claims_test.go
@@ -18,11 +18,6 @@ func TestGetCustomClaim(t *testing.T) {
 		want any
 	}{
 		{
-			name: "nil-context",
-			ctx:  nil,
-			want: nil,
-		},
-		{
 			name: "no-claim-in-context",
 			ctx:  context.Background(),
 			want: nil,

--- a/controller/control.go
+++ b/controller/control.go
@@ -56,6 +56,21 @@ func IsMonitoring(cl *jwt.Claims) bool {
 	return cl.Subject == monitorSubject
 }
 
+// SetupOption configures optional behavior for Setup.
+type SetupOption func(*setupConfig)
+
+type setupConfig struct {
+	newCustomClaim func() any
+}
+
+// WithCustomClaim configures Setup to install a NewCustomClaim factory on the
+// TokenController it builds. The factory is invoked per request to allocate a
+// destination struct for caller-defined JWT claims. See
+// TokenController.NewCustomClaim for the full contract.
+func WithCustomClaim(factory func() any) SetupOption {
+	return func(c *setupConfig) { c.newCustomClaim = factory }
+}
+
 // Setup creates a sequence of access control http.Handlers. When the verifier
 // is nil then the token controller will be excluded from the returned handler
 // chain. When the tx controller is unconfigured then the tx controller will be
@@ -63,8 +78,14 @@ func IsMonitoring(cl *jwt.Claims) bool {
 // because it provides the Accepter interface for use by servers accepting raw
 // TCP connections. See TxController.Accept for more information. When
 // tokenRequired is true, then the token controller requires valid access tokens
-// for the named machine.
-func Setup(ctx context.Context, v Verifier, tokenRequired bool, machine string, txEnf, tkEnf Paths) (alice.Chain, *TxController) {
+// for the named machine. Optional SetupOptions configure extensions such as
+// custom JWT claim extraction; see WithCustomClaim.
+func Setup(ctx context.Context, v Verifier, tokenRequired bool, machine string, txEnf, tkEnf Paths, opts ...SetupOption) (alice.Chain, *TxController) {
+	cfg := setupConfig{}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
 	// Controllers must be applied in specific order so that the tx controller
 	// can access the access token claims (if present) to identify monitoring
 	// requests. When token validation is successful, the validated claims are
@@ -79,6 +100,9 @@ func Setup(ctx context.Context, v Verifier, tokenRequired bool, machine string, 
 	}
 	token, err := NewTokenController(v, tokenRequired, exp, tkEnf)
 	if err == nil {
+		if cfg.newCustomClaim != nil {
+			token.NewCustomClaim = cfg.newCustomClaim
+		}
 		ac = ac.Append(token.Limit)
 	} else {
 		log.Printf("WARNING: token controller is disabled: %v", err)

--- a/controller/control.go
+++ b/controller/control.go
@@ -10,6 +10,7 @@ import (
 	// Alice package provides a light weight way to chain HTTP middleware functions.
 	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/justinas/alice"
+	"github.com/m-lab/access/token"
 )
 
 // TODO: replace with constants from the locate service repository.
@@ -46,6 +47,28 @@ func GetClaim(ctx context.Context) *jwt.Claims {
 		return nil
 	}
 	return value.(*jwt.Claims)
+}
+
+type integrationClaimsContextKeyType struct{}
+
+var integrationClaimsContextKey = integrationClaimsContextKeyType{}
+
+// SetIntegrationClaims returns a derived context with the given integration claims.
+func SetIntegrationClaims(ctx context.Context, ic *token.IntegrationClaims) context.Context {
+	return context.WithValue(ctx, integrationClaimsContextKey, ic)
+}
+
+// GetIntegrationClaims extracts integration claims from the given context.
+// Returns nil if no integration claims are present.
+func GetIntegrationClaims(ctx context.Context) *token.IntegrationClaims {
+	if ctx == nil {
+		return nil
+	}
+	value := ctx.Value(integrationClaimsContextKey)
+	if value == nil {
+		return nil
+	}
+	return value.(*token.IntegrationClaims)
 }
 
 // IsMonitoring reports whether (possibly nil) claim is from a monitoring issuer.

--- a/controller/control.go
+++ b/controller/control.go
@@ -10,7 +10,6 @@ import (
 	// Alice package provides a light weight way to chain HTTP middleware functions.
 	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/justinas/alice"
-	"github.com/m-lab/access/token"
 )
 
 // TODO: replace with constants from the locate service repository.
@@ -47,28 +46,6 @@ func GetClaim(ctx context.Context) *jwt.Claims {
 		return nil
 	}
 	return value.(*jwt.Claims)
-}
-
-type integrationClaimsContextKeyType struct{}
-
-var integrationClaimsContextKey = integrationClaimsContextKeyType{}
-
-// SetIntegrationClaims returns a derived context with the given integration claims.
-func SetIntegrationClaims(ctx context.Context, ic *token.IntegrationClaims) context.Context {
-	return context.WithValue(ctx, integrationClaimsContextKey, ic)
-}
-
-// GetIntegrationClaims extracts integration claims from the given context.
-// Returns nil if no integration claims are present.
-func GetIntegrationClaims(ctx context.Context) *token.IntegrationClaims {
-	if ctx == nil {
-		return nil
-	}
-	value := ctx.Value(integrationClaimsContextKey)
-	if value == nil {
-		return nil
-	}
-	return value.(*token.IntegrationClaims)
 }
 
 // IsMonitoring reports whether (possibly nil) claim is from a monitoring issuer.

--- a/controller/control_test.go
+++ b/controller/control_test.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
+	"time"
 
 	"github.com/go-jose/go-jose/v4/jwt"
+	"github.com/go-test/deep"
 	"github.com/justinas/alice"
 )
 
@@ -97,5 +100,42 @@ func TestSetupDefault(t *testing.T) {
 				t.Errorf("Setup() Then() not visited; got false, want true")
 			}
 		})
+	}
+}
+
+func TestSetupWithCustomClaim(t *testing.T) {
+	procPath = "testdata/proc-success"
+	device = "eth0"
+	machine := "mlab1.foo01"
+	enforced := Paths{"/": true}
+	verifier := &fakeVerifier{
+		claims: &jwt.Claims{
+			Issuer:   locateIssuer,
+			Audience: jwt.Audience{machine},
+			Expiry:   jwt.NewNumericDate(time.Now().Add(time.Minute)),
+		},
+		custom: &testCustomClaims{Foo: "f", Bar: "b"},
+	}
+
+	ac, _ := Setup(context.Background(), verifier, true, machine, enforced, enforced,
+		WithCustomClaim(func() any { return &testCustomClaims{} }),
+	)
+
+	var gotCustom any
+	next := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		gotCustom = GetCustomClaim(req.Context())
+	})
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Form = url.Values{"access_token": {"fake-token"}}
+	rw := httptest.NewRecorder()
+
+	ac.Then(next).ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusOK {
+		t.Errorf("Setup() with custom claim wrong http code; got %d, want %d", rw.Code, http.StatusOK)
+	}
+	want := &testCustomClaims{Foo: "f", Bar: "b"}
+	if diff := deep.Equal(gotCustom, want); diff != nil {
+		t.Errorf("Setup() with custom claim mismatch: %v", diff)
 	}
 }

--- a/controller/control_test.go
+++ b/controller/control_test.go
@@ -7,9 +7,7 @@ import (
 	"testing"
 
 	"github.com/go-jose/go-jose/v4/jwt"
-	"github.com/go-test/deep"
 	"github.com/justinas/alice"
-	"github.com/m-lab/access/token"
 )
 
 func TestGetClaim(t *testing.T) {
@@ -43,44 +41,6 @@ func TestIsMonitoring(t *testing.T) {
 	}
 	if IsMonitoring(nil) {
 		t.Errorf("IsMonitoring() did not recognize monitoring issuer; got true, want false")
-	}
-}
-
-func TestGetIntegrationClaims(t *testing.T) {
-	tests := []struct {
-		name string
-		ctx  context.Context
-		want *token.IntegrationClaims
-	}{
-		{
-			name: "nil-context",
-			ctx:  nil,
-			want: nil,
-		},
-		{
-			name: "no-claims-in-context",
-			ctx:  context.Background(),
-			want: nil,
-		},
-		{
-			name: "with-integration-claims",
-			ctx: SetIntegrationClaims(context.Background(), &token.IntegrationClaims{
-				IntegrationID: "test-int",
-				KeyID:         "ki_test",
-			}),
-			want: &token.IntegrationClaims{
-				IntegrationID: "test-int",
-				KeyID:         "ki_test",
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := GetIntegrationClaims(tt.ctx)
-			if diff := deep.Equal(got, tt.want); diff != nil {
-				t.Errorf("GetIntegrationClaims() mismatch: %v", diff)
-			}
-		})
 	}
 }
 

--- a/controller/control_test.go
+++ b/controller/control_test.go
@@ -7,7 +7,9 @@ import (
 	"testing"
 
 	"github.com/go-jose/go-jose/v4/jwt"
+	"github.com/go-test/deep"
 	"github.com/justinas/alice"
+	"github.com/m-lab/access/token"
 )
 
 func TestGetClaim(t *testing.T) {
@@ -41,6 +43,44 @@ func TestIsMonitoring(t *testing.T) {
 	}
 	if IsMonitoring(nil) {
 		t.Errorf("IsMonitoring() did not recognize monitoring issuer; got true, want false")
+	}
+}
+
+func TestGetIntegrationClaims(t *testing.T) {
+	tests := []struct {
+		name string
+		ctx  context.Context
+		want *token.IntegrationClaims
+	}{
+		{
+			name: "nil-context",
+			ctx:  nil,
+			want: nil,
+		},
+		{
+			name: "no-claims-in-context",
+			ctx:  context.Background(),
+			want: nil,
+		},
+		{
+			name: "with-integration-claims",
+			ctx: SetIntegrationClaims(context.Background(), &token.IntegrationClaims{
+				IntegrationID: "test-int",
+				KeyID:         "ki_test",
+			}),
+			want: &token.IntegrationClaims{
+				IntegrationID: "test-int",
+				KeyID:         "ki_test",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetIntegrationClaims(tt.ctx)
+			if diff := deep.Equal(got, tt.want); diff != nil {
+				t.Errorf("GetIntegrationClaims() mismatch: %v", diff)
+			}
+		})
 	}
 }
 

--- a/controller/token.go
+++ b/controller/token.go
@@ -47,6 +47,13 @@ type TokenController struct {
 	// TokenController will enforce token authorization. Any resource missing
 	// from the Enforced set is allowed.
 	Enforced Paths
+
+	// NewCustomClaim, if non-nil, is called per request to allocate a
+	// destination for caller-defined JWT claims. The returned pointer is
+	// passed to Verifier.Verify; on successful verification it is attached
+	// to the request context via SetCustomClaim so downstream handlers can
+	// retrieve it with GetCustomClaim.
+	NewCustomClaim func() any
 }
 
 // Verifier is used by the TokenController to verify JWT claims in access
@@ -100,9 +107,9 @@ func (t *TokenController) Limit(next http.Handler) http.Handler {
 // isVerified validates the client-provided access_token. If the access_token is
 // not found and tokens are not required, the request will be accepted. If the
 // token is valid, then the returned context will include a boolean value
-// indicating whether the token issuer is "monitoring" or not. When the token
-// carries non-empty integration claims, they are also attached to the context
-// via SetIntegrationClaims.
+// indicating whether the token issuer is "monitoring" or not. When
+// NewCustomClaim is set, the populated custom claim value is also attached to
+// the context via SetCustomClaim.
 func (t *TokenController) isVerified(r *http.Request) (bool, context.Context) {
 	ctx := r.Context()
 	// NOTE: r.Form is not populated until calling ParseForm.
@@ -131,8 +138,13 @@ func (t *TokenController) isVerified(r *http.Request) (bool, context.Context) {
 	exp := t.Expected
 	exp.Time = time.Now()
 
-	ic := &IntegrationClaims{}
-	cl, verifyErr := t.Public.Verify(accessToken, exp, ic)
+	var custom any
+	var extraDest []any
+	if t.NewCustomClaim != nil {
+		custom = t.NewCustomClaim()
+		extraDest = []any{custom}
+	}
+	cl, verifyErr := t.Public.Verify(accessToken, exp, extraDest...)
 	if verifyErr != nil {
 		reason := strings.TrimPrefix(verifyErr.Error(), "go-jose/go-jose/jwt: validation failed, ")
 		tokenAccessRequests.WithLabelValues(pathLabel, "rejected", reason).Inc()
@@ -140,8 +152,8 @@ func (t *TokenController) isVerified(r *http.Request) (bool, context.Context) {
 	}
 
 	ctx = SetClaim(ctx, cl)
-	if ic.IntegrationID != "" || ic.KeyID != "" {
-		ctx = SetIntegrationClaims(ctx, ic)
+	if custom != nil {
+		ctx = SetCustomClaim(ctx, custom)
 	}
 	tokenAccessRequests.WithLabelValues(pathLabel, "accepted", cl.Issuer).Inc()
 	return true, ctx

--- a/controller/token.go
+++ b/controller/token.go
@@ -100,7 +100,9 @@ func (t *TokenController) Limit(next http.Handler) http.Handler {
 // isVerified validates the client-provided access_token. If the access_token is
 // not found and tokens are not required, the request will be accepted. If the
 // token is valid, then the returned context will include a boolean value
-// indicating whether the token issuer is "monitoring" or not.
+// indicating whether the token issuer is "monitoring" or not. When the token
+// carries non-empty integration claims, they are also attached to the context
+// via SetIntegrationClaims.
 func (t *TokenController) isVerified(r *http.Request) (bool, context.Context) {
 	ctx := r.Context()
 	// NOTE: r.Form is not populated until calling ParseForm.

--- a/controller/token.go
+++ b/controller/token.go
@@ -49,9 +49,11 @@ type TokenController struct {
 	Enforced Paths
 
 	// NewCustomClaim, if non-nil, is called per request to allocate a
-	// destination for caller-defined JWT claims. The returned pointer is
-	// passed to Verifier.Verify; on successful verification it is attached
-	// to the request context via SetCustomClaim so downstream handlers can
+	// destination for caller-defined JWT claims. It must return a non-nil
+	// pointer to a JSON-decodable struct, or nil to skip custom claim
+	// extraction for this request. The returned pointer is passed to
+	// Verifier.Verify; on successful verification it is attached to the
+	// request context via SetCustomClaim so downstream handlers can
 	// retrieve it with GetCustomClaim.
 	NewCustomClaim func() any
 }
@@ -141,8 +143,10 @@ func (t *TokenController) isVerified(r *http.Request) (bool, context.Context) {
 	var custom any
 	var extraDest []any
 	if t.NewCustomClaim != nil {
-		custom = t.NewCustomClaim()
-		extraDest = []any{custom}
+		if c := t.NewCustomClaim(); c != nil {
+			custom = c
+			extraDest = []any{c}
+		}
 	}
 	cl, verifyErr := t.Public.Verify(accessToken, exp, extraDest...)
 	if verifyErr != nil {

--- a/controller/token.go
+++ b/controller/token.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/go-jose/go-jose/v4/jwt"
-	"github.com/m-lab/access/token"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
@@ -51,17 +50,10 @@ type TokenController struct {
 }
 
 // Verifier is used by the TokenController to verify JWT claims in access
-// tokens.
+// tokens. Extra destination pointers are unmarshaled from the same JWT
+// payload (see token.Verifier.Verify).
 type Verifier interface {
-	Verify(token string, exp jwt.Expected) (*jwt.Claims, error)
-}
-
-// IntegrationVerifier is an optional interface that token verifiers can
-// implement to extract integration-specific claims (int_id, key_id) alongside
-// standard JWT claims. When the verifier implements this interface,
-// isVerified() uses it instead of Verify() to avoid double-parsing the token.
-type IntegrationVerifier interface {
-	VerifyWithIntegrationClaims(tok string, exp jwt.Expected) (*jwt.Claims, *token.IntegrationClaims, error)
+	Verify(token string, exp jwt.Expected, extraDest ...any) (*jwt.Claims, error)
 }
 
 // NewTokenController creates a new token controller that requires tokens (or
@@ -137,31 +129,18 @@ func (t *TokenController) isVerified(r *http.Request) (bool, context.Context) {
 	exp := t.Expected
 	exp.Time = time.Now()
 
-	var cl *jwt.Claims
-	var verifyErr error
-
-	if iv, ok := t.Public.(IntegrationVerifier); ok {
-		var ic *token.IntegrationClaims
-		cl, ic, verifyErr = iv.VerifyWithIntegrationClaims(accessToken, exp)
-		if verifyErr == nil {
-			ctx = SetClaim(ctx, cl)
-			if ic.IntegrationID != "" || ic.KeyID != "" {
-				ctx = SetIntegrationClaims(ctx, ic)
-			}
-		}
-	} else {
-		cl, verifyErr = t.Public.Verify(accessToken, exp)
-		if verifyErr == nil {
-			ctx = SetClaim(ctx, cl)
-		}
-	}
-
+	ic := &IntegrationClaims{}
+	cl, verifyErr := t.Public.Verify(accessToken, exp, ic)
 	if verifyErr != nil {
-		reason := strings.TrimPrefix(verifyErr.Error(), "square/go-jose/jwt: validation failed, ")
+		reason := strings.TrimPrefix(verifyErr.Error(), "go-jose/go-jose/jwt: validation failed, ")
 		tokenAccessRequests.WithLabelValues(pathLabel, "rejected", reason).Inc()
 		return false, ctx
 	}
 
+	ctx = SetClaim(ctx, cl)
+	if ic.IntegrationID != "" || ic.KeyID != "" {
+		ctx = SetIntegrationClaims(ctx, ic)
+	}
 	tokenAccessRequests.WithLabelValues(pathLabel, "accepted", cl.Issuer).Inc()
 	return true, ctx
 }

--- a/controller/token.go
+++ b/controller/token.go
@@ -52,9 +52,14 @@ type TokenController struct {
 	// destination for caller-defined JWT claims. It must return a non-nil
 	// pointer to a JSON-decodable struct, or nil to skip custom claim
 	// extraction for this request. The returned pointer is passed to
-	// Verifier.Verify; on successful verification it is attached to the
-	// request context via SetCustomClaim so downstream handlers can
-	// retrieve it with GetCustomClaim.
+	// Verifier.Verify. On successful signature authentication and
+	// standard-claim policy check, it is attached to the request context
+	// via SetCustomClaim so downstream handlers can retrieve it with
+	// GetCustomClaim.
+	//
+	// Callers are responsible for validating the contents of the custom
+	// struct (e.g., scope or role fields) in their downstream handler;
+	// this hook performs no value-level policy check on custom fields.
 	NewCustomClaim func() any
 }
 

--- a/controller/token.go
+++ b/controller/token.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/go-jose/go-jose/v4/jwt"
+	"github.com/m-lab/access/token"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
@@ -53,6 +54,14 @@ type TokenController struct {
 // tokens.
 type Verifier interface {
 	Verify(token string, exp jwt.Expected) (*jwt.Claims, error)
+}
+
+// IntegrationVerifier is an optional interface that token verifiers can
+// implement to extract integration-specific claims (int_id, key_id) alongside
+// standard JWT claims. When the verifier implements this interface,
+// isVerified() uses it instead of Verify() to avoid double-parsing the token.
+type IntegrationVerifier interface {
+	VerifyWithIntegrationClaims(tok string, exp jwt.Expected) (*jwt.Claims, *token.IntegrationClaims, error)
 }
 
 // NewTokenController creates a new token controller that requires tokens (or
@@ -104,7 +113,7 @@ func (t *TokenController) isVerified(r *http.Request) (bool, context.Context) {
 	ctx := r.Context()
 	// NOTE: r.Form is not populated until calling ParseForm.
 	r.ParseForm()
-	token := r.Form.Get("access_token")
+	accessToken := r.Form.Get("access_token")
 	pathLabel := "unknown"
 	if !t.Enforced[r.URL.Path] {
 		// This path is not in the Enforced set, so accept the connection.
@@ -114,12 +123,12 @@ func (t *TokenController) isVerified(r *http.Request) (bool, context.Context) {
 
 	// The path is an enforced path, so copy it wholesale as a label.
 	pathLabel = r.URL.Path
-	if token == "" && !t.Required {
+	if accessToken == "" && !t.Required {
 		// The access token is missing and tokens are not requried, so accept the request.
 		tokenAccessRequests.WithLabelValues(pathLabel, "accepted", "empty").Inc()
 		return true, ctx
 	}
-	if token == "" {
+	if accessToken == "" {
 		// The access token was required but not provided.
 		tokenAccessRequests.WithLabelValues(pathLabel, "rejected", "missing").Inc()
 		return false, ctx
@@ -127,15 +136,32 @@ func (t *TokenController) isVerified(r *http.Request) (bool, context.Context) {
 	// Attempt to verify the token.
 	exp := t.Expected
 	exp.Time = time.Now()
-	cl, err := t.Public.Verify(token, exp)
-	if err != nil {
-		// The access token was invalid; reject this request.
-		reason := strings.TrimPrefix(err.Error(), "square/go-jose/jwt: validation failed, ")
+
+	var cl *jwt.Claims
+	var verifyErr error
+
+	if iv, ok := t.Public.(IntegrationVerifier); ok {
+		var ic *token.IntegrationClaims
+		cl, ic, verifyErr = iv.VerifyWithIntegrationClaims(accessToken, exp)
+		if verifyErr == nil {
+			ctx = SetClaim(ctx, cl)
+			if ic.IntegrationID != "" || ic.KeyID != "" {
+				ctx = SetIntegrationClaims(ctx, ic)
+			}
+		}
+	} else {
+		cl, verifyErr = t.Public.Verify(accessToken, exp)
+		if verifyErr == nil {
+			ctx = SetClaim(ctx, cl)
+		}
+	}
+
+	if verifyErr != nil {
+		reason := strings.TrimPrefix(verifyErr.Error(), "square/go-jose/jwt: validation failed, ")
 		tokenAccessRequests.WithLabelValues(pathLabel, "rejected", reason).Inc()
 		return false, ctx
 	}
-	// If the claim Issuer was monitoring, set the context value so subsequent
-	// access controllers can check the context to allow monitoring reqeusts.
+
 	tokenAccessRequests.WithLabelValues(pathLabel, "accepted", cl.Issuer).Inc()
-	return true, SetClaim(ctx, cl)
+	return true, ctx
 }

--- a/controller/token_test.go
+++ b/controller/token_test.go
@@ -9,30 +9,23 @@ import (
 	"time"
 
 	"github.com/go-jose/go-jose/v4/jwt"
-	"github.com/m-lab/access/token"
 )
 
 type fakeVerifier struct {
 	claims *jwt.Claims
+	ic     *IntegrationClaims // if non-nil, populates extra dest
 	err    error
 }
 
-func (f *fakeVerifier) Verify(token string, exp jwt.Expected) (*jwt.Claims, error) {
+func (f *fakeVerifier) Verify(tok string, exp jwt.Expected, extraDest ...any) (*jwt.Claims, error) {
+	if f.ic != nil {
+		for _, d := range extraDest {
+			if ic, ok := d.(*IntegrationClaims); ok {
+				*ic = *f.ic
+			}
+		}
+	}
 	return f.claims, f.err
-}
-
-type fakeIntegrationVerifier struct {
-	claims *jwt.Claims
-	ic     *token.IntegrationClaims
-	err    error
-}
-
-func (f *fakeIntegrationVerifier) Verify(tok string, exp jwt.Expected) (*jwt.Claims, error) {
-	return f.claims, f.err
-}
-
-func (f *fakeIntegrationVerifier) VerifyWithIntegrationClaims(tok string, exp jwt.Expected) (*jwt.Claims, *token.IntegrationClaims, error) {
-	return f.claims, f.ic, f.err
 }
 
 func TestTokenController_Limit(t *testing.T) {
@@ -189,13 +182,13 @@ func TestTokenController_Limit(t *testing.T) {
 			name:    "success-with-integration-claims",
 			issuer:  locateIssuer,
 			machine: "mlab1.fake0",
-			verifier: &fakeIntegrationVerifier{
+			verifier: &fakeVerifier{
 				claims: &jwt.Claims{
 					Issuer:   locateIssuer,
 					Audience: []string{"mlab1.fake0"},
 					Expiry:   jwt.NewNumericDate(time.Now()),
 				},
-				ic: &token.IntegrationClaims{
+				ic: &IntegrationClaims{
 					IntegrationID: "test-int",
 					KeyID:         "ki_test",
 				},
@@ -210,13 +203,12 @@ func TestTokenController_Limit(t *testing.T) {
 			name:    "success-with-empty-integration-claims",
 			issuer:  locateIssuer,
 			machine: "mlab1.fake0",
-			verifier: &fakeIntegrationVerifier{
+			verifier: &fakeVerifier{
 				claims: &jwt.Claims{
 					Issuer:   locateIssuer,
 					Audience: []string{"mlab1.fake0"},
 					Expiry:   jwt.NewNumericDate(time.Now()),
 				},
-				ic: &token.IntegrationClaims{},
 			},
 			required: true,
 			token:    "this-is-a-fake-token",
@@ -241,7 +233,7 @@ func TestTokenController_Limit(t *testing.T) {
 
 			visited := false
 			isMonitoring := false
-			var gotIC *token.IntegrationClaims
+			var gotIC *IntegrationClaims
 			next := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 				visited = true
 				isMonitoring = IsMonitoring(GetClaim(req.Context()))

--- a/controller/token_test.go
+++ b/controller/token_test.go
@@ -9,19 +9,27 @@ import (
 	"time"
 
 	"github.com/go-jose/go-jose/v4/jwt"
+	"github.com/go-test/deep"
 )
+
+// testCustomClaims is a sample caller-defined claim type used to exercise the
+// generic NewCustomClaim/SetCustomClaim/GetCustomClaim machinery.
+type testCustomClaims struct {
+	Foo string
+	Bar string
+}
 
 type fakeVerifier struct {
 	claims *jwt.Claims
-	ic     *IntegrationClaims // if non-nil, populates extra dest
+	custom *testCustomClaims // if non-nil, populates extra dest
 	err    error
 }
 
 func (f *fakeVerifier) Verify(tok string, exp jwt.Expected, extraDest ...any) (*jwt.Claims, error) {
-	if f.ic != nil {
+	if f.custom != nil {
 		for _, d := range extraDest {
-			if ic, ok := d.(*IntegrationClaims); ok {
-				*ic = *f.ic
+			if c, ok := d.(*testCustomClaims); ok {
+				*c = *f.custom
 			}
 		}
 	}
@@ -41,6 +49,8 @@ func TestTokenController_Limit(t *testing.T) {
 		monitoring bool
 		expected   Paths
 		wantErr    bool
+		newCustom  func() any
+		wantCustom any
 	}{
 		{
 			name:    "success-without-token",
@@ -179,7 +189,7 @@ func TestTokenController_Limit(t *testing.T) {
 			wantErr:  true,
 		},
 		{
-			name:    "success-with-integration-claims",
+			name:    "success-with-custom-claim",
 			issuer:  locateIssuer,
 			machine: "mlab1.fake0",
 			verifier: &fakeVerifier{
@@ -188,19 +198,18 @@ func TestTokenController_Limit(t *testing.T) {
 					Audience: []string{"mlab1.fake0"},
 					Expiry:   jwt.NewNumericDate(time.Now()),
 				},
-				ic: &IntegrationClaims{
-					IntegrationID: "test-int",
-					KeyID:         "ki_test",
-				},
+				custom: &testCustomClaims{Foo: "f", Bar: "b"},
 			},
-			required: true,
-			token:    "this-is-a-fake-token",
-			code:     http.StatusOK,
-			visited:  true,
-			expected: Paths{"/": true},
+			required:   true,
+			token:      "this-is-a-fake-token",
+			code:       http.StatusOK,
+			visited:    true,
+			expected:   Paths{"/": true},
+			newCustom:  func() any { return &testCustomClaims{} },
+			wantCustom: &testCustomClaims{Foo: "f", Bar: "b"},
 		},
 		{
-			name:    "success-with-empty-integration-claims",
+			name:    "success-with-zero-custom-claim",
 			issuer:  locateIssuer,
 			machine: "mlab1.fake0",
 			verifier: &fakeVerifier{
@@ -210,11 +219,13 @@ func TestTokenController_Limit(t *testing.T) {
 					Expiry:   jwt.NewNumericDate(time.Now()),
 				},
 			},
-			required: true,
-			token:    "this-is-a-fake-token",
-			code:     http.StatusOK,
-			visited:  true,
-			expected: Paths{"/": true},
+			required:   true,
+			token:      "this-is-a-fake-token",
+			code:       http.StatusOK,
+			visited:    true,
+			expected:   Paths{"/": true},
+			newCustom:  func() any { return &testCustomClaims{} },
+			wantCustom: &testCustomClaims{},
 		},
 	}
 	for _, tt := range tests {
@@ -230,14 +241,15 @@ func TestTokenController_Limit(t *testing.T) {
 			if tt.wantErr {
 				return
 			}
+			tc.NewCustomClaim = tt.newCustom
 
 			visited := false
 			isMonitoring := false
-			var gotIC *IntegrationClaims
+			var gotCustom any
 			next := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 				visited = true
 				isMonitoring = IsMonitoring(GetClaim(req.Context()))
-				gotIC = GetIntegrationClaims(req.Context())
+				gotCustom = GetCustomClaim(req.Context())
 			})
 			req := httptest.NewRequest(http.MethodGet, "/", nil)
 			req.Form = url.Values{}
@@ -257,22 +269,8 @@ func TestTokenController_Limit(t *testing.T) {
 			if isMonitoring != tt.monitoring {
 				t.Errorf("TokenController.Limit() monitoring is wrong; got %t, want %t", isMonitoring, tt.monitoring)
 			}
-			if tt.name == "success-with-integration-claims" {
-				if gotIC == nil {
-					t.Error("Expected integration claims in context, got nil")
-				} else {
-					if gotIC.IntegrationID != "test-int" {
-						t.Errorf("Expected int_id 'test-int', got %q", gotIC.IntegrationID)
-					}
-					if gotIC.KeyID != "ki_test" {
-						t.Errorf("Expected key_id 'ki_test', got %q", gotIC.KeyID)
-					}
-				}
-			}
-			if tt.name == "success-with-empty-integration-claims" {
-				if gotIC != nil {
-					t.Errorf("Expected no integration claims for empty claims, got %+v", gotIC)
-				}
+			if diff := deep.Equal(gotCustom, tt.wantCustom); diff != nil {
+				t.Errorf("TokenController.Limit() custom claim mismatch: %v", diff)
 			}
 		})
 	}

--- a/controller/token_test.go
+++ b/controller/token_test.go
@@ -227,6 +227,28 @@ func TestTokenController_Limit(t *testing.T) {
 			newCustom:  func() any { return &testCustomClaims{} },
 			wantCustom: &testCustomClaims{},
 		},
+		{
+			// NewCustomClaim returning nil must be tolerated and must NOT
+			// cause the request to be rejected (no extra dest is sent to
+			// Verify, and no value is attached to the context).
+			name:    "success-with-nil-custom-claim",
+			issuer:  locateIssuer,
+			machine: "mlab1.fake0",
+			verifier: &fakeVerifier{
+				claims: &jwt.Claims{
+					Issuer:   locateIssuer,
+					Audience: []string{"mlab1.fake0"},
+					Expiry:   jwt.NewNumericDate(time.Now()),
+				},
+			},
+			required:   true,
+			token:      "this-is-a-fake-token",
+			code:       http.StatusOK,
+			visited:    true,
+			expected:   Paths{"/": true},
+			newCustom:  func() any { return nil },
+			wantCustom: nil,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/controller/token_test.go
+++ b/controller/token_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/go-jose/go-jose/v4/jwt"
+	"github.com/m-lab/access/token"
 )
 
 type fakeVerifier struct {
@@ -20,12 +21,26 @@ func (f *fakeVerifier) Verify(token string, exp jwt.Expected) (*jwt.Claims, erro
 	return f.claims, f.err
 }
 
+type fakeIntegrationVerifier struct {
+	claims *jwt.Claims
+	ic     *token.IntegrationClaims
+	err    error
+}
+
+func (f *fakeIntegrationVerifier) Verify(tok string, exp jwt.Expected) (*jwt.Claims, error) {
+	return f.claims, f.err
+}
+
+func (f *fakeIntegrationVerifier) VerifyWithIntegrationClaims(tok string, exp jwt.Expected) (*jwt.Claims, *token.IntegrationClaims, error) {
+	return f.claims, f.ic, f.err
+}
+
 func TestTokenController_Limit(t *testing.T) {
 	tests := []struct {
 		name       string
 		issuer     string
 		machine    string
-		verifier   *fakeVerifier
+		verifier   Verifier
 		required   bool
 		token      string
 		code       int
@@ -132,7 +147,7 @@ func TestTokenController_Limit(t *testing.T) {
 			name:     "error-nil-verifier",
 			issuer:   locateIssuer,
 			machine:  "mlab1.fake0",
-			verifier: nil,
+			verifier: (*fakeVerifier)(nil),
 			required: true,
 			expected: Paths{"/": true},
 			wantErr:  true,
@@ -170,6 +185,45 @@ func TestTokenController_Limit(t *testing.T) {
 			expected: nil,
 			wantErr:  true,
 		},
+		{
+			name:    "success-with-integration-claims",
+			issuer:  locateIssuer,
+			machine: "mlab1.fake0",
+			verifier: &fakeIntegrationVerifier{
+				claims: &jwt.Claims{
+					Issuer:   locateIssuer,
+					Audience: []string{"mlab1.fake0"},
+					Expiry:   jwt.NewNumericDate(time.Now()),
+				},
+				ic: &token.IntegrationClaims{
+					IntegrationID: "test-int",
+					KeyID:         "ki_test",
+				},
+			},
+			required: true,
+			token:    "this-is-a-fake-token",
+			code:     http.StatusOK,
+			visited:  true,
+			expected: Paths{"/": true},
+		},
+		{
+			name:    "success-with-empty-integration-claims",
+			issuer:  locateIssuer,
+			machine: "mlab1.fake0",
+			verifier: &fakeIntegrationVerifier{
+				claims: &jwt.Claims{
+					Issuer:   locateIssuer,
+					Audience: []string{"mlab1.fake0"},
+					Expiry:   jwt.NewNumericDate(time.Now()),
+				},
+				ic: &token.IntegrationClaims{},
+			},
+			required: true,
+			token:    "this-is-a-fake-token",
+			code:     http.StatusOK,
+			visited:  true,
+			expected: Paths{"/": true},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -177,7 +231,7 @@ func TestTokenController_Limit(t *testing.T) {
 				Issuer:      tt.issuer,
 				AnyAudience: jwt.Audience{tt.machine},
 			}
-			token, err := NewTokenController(tt.verifier, tt.required, exp, tt.expected)
+			tc, err := NewTokenController(tt.verifier, tt.required, exp, tt.expected)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("NewTokenController() returned err; got %v, wantErr %t", err, tt.wantErr)
 			}
@@ -187,9 +241,11 @@ func TestTokenController_Limit(t *testing.T) {
 
 			visited := false
 			isMonitoring := false
+			var gotIC *token.IntegrationClaims
 			next := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 				visited = true
 				isMonitoring = IsMonitoring(GetClaim(req.Context()))
+				gotIC = GetIntegrationClaims(req.Context())
 			})
 			req := httptest.NewRequest(http.MethodGet, "/", nil)
 			req.Form = url.Values{}
@@ -198,7 +254,7 @@ func TestTokenController_Limit(t *testing.T) {
 			}
 			rw := httptest.NewRecorder()
 
-			token.Limit(next).ServeHTTP(rw, req)
+			tc.Limit(next).ServeHTTP(rw, req)
 
 			if rw.Code != tt.code {
 				t.Errorf("TokenController.Limit() wrong http code; got %d, want %d", rw.Code, tt.code)
@@ -208,6 +264,23 @@ func TestTokenController_Limit(t *testing.T) {
 			}
 			if isMonitoring != tt.monitoring {
 				t.Errorf("TokenController.Limit() monitoring is wrong; got %t, want %t", isMonitoring, tt.monitoring)
+			}
+			if tt.name == "success-with-integration-claims" {
+				if gotIC == nil {
+					t.Error("Expected integration claims in context, got nil")
+				} else {
+					if gotIC.IntegrationID != "test-int" {
+						t.Errorf("Expected int_id 'test-int', got %q", gotIC.IntegrationID)
+					}
+					if gotIC.KeyID != "ki_test" {
+						t.Errorf("Expected key_id 'ki_test', got %q", gotIC.KeyID)
+					}
+				}
+			}
+			if tt.name == "success-with-empty-integration-claims" {
+				if gotIC != nil {
+					t.Errorf("Expected no integration claims for empty claims, got %+v", gotIC)
+				}
 			}
 		})
 	}

--- a/token/jwt.go
+++ b/token/jwt.go
@@ -131,6 +131,9 @@ func (k *Verifier) Claims(token string) (*jwt.Claims, error) {
 //
 //	var custom MyCustomClaims
 //	cl, err := v.Verify(token, expected, &custom)
+//
+// If parsing succeeds but expected-claims validation fails, Verify returns the
+// parsed claims along with the non-nil validation error.
 func (k *Verifier) Verify(token string, exp jwt.Expected, extraDest ...any) (*jwt.Claims, error) {
 	tok, pub, err := k.parsedToken(token)
 	if err != nil {

--- a/token/jwt.go
+++ b/token/jwt.go
@@ -91,42 +91,56 @@ func NewVerifier(keys ...[]byte) (*Verifier, error) {
 	}, nil
 }
 
-// Claims extracts the claims from a signed token, but does not
-// validate them against any expected claims. Useful for extracting
-// only the claims object.
-func (k *Verifier) Claims(token string) (*jwt.Claims, error) {
+// parsedToken parses a signed token string and resolves the signing key.
+func (k *Verifier) parsedToken(token string) (*jwt.JSONWebToken, *jose.JSONWebKey, error) {
 	tok, err := jwt.ParseSigned(token, supportedAlgorithms)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-
 	headers := tok.Headers
 	if len(headers) == 0 {
-		return nil, errors.New("no headers found in token")
+		return nil, nil, errors.New("no headers found in token")
 	}
-
 	// Note: We will not support tokens with multiple signatures/headers.
 	keyID := headers[0].KeyID
 	pub, found := k.keys[keyID]
 	if !found {
-		return nil, fmt.Errorf("%w: %s", ErrKeyIDNotFound, keyID)
+		return nil, nil, fmt.Errorf("%w: %s", ErrKeyIDNotFound, keyID)
 	}
+	return tok, pub, nil
+}
 
-	// Claims validates the jwt signature before extracting the token claims.
-	cl := &jwt.Claims{}
-	err = tok.Claims(pub, cl)
+// Claims extracts the claims from a signed token, but does not
+// validate them against any expected claims. Useful for extracting
+// only the claims object.
+func (k *Verifier) Claims(token string) (*jwt.Claims, error) {
+	tok, pub, err := k.parsedToken(token)
 	if err != nil {
+		return nil, err
+	}
+	cl := &jwt.Claims{}
+	if err := tok.Claims(pub, cl); err != nil {
 		return nil, err
 	}
 	return cl, nil
 }
 
-// Verify checks the token signature and that the claims match the expected
-// config. Note: if validation of the expected claims fails, then Verify will
-// return the original token claims with the corresponding non-nil validation error.
-func (k *Verifier) Verify(token string, exp jwt.Expected) (*jwt.Claims, error) {
-	cl, err := k.Claims(token)
+// Verify checks the token signature and validates claims against expected
+// values. Extra destination pointers are unmarshaled from the same JWT payload
+// via go-jose's variadic Claims support. For example:
+//
+//	var custom MyCustomClaims
+//	cl, err := v.Verify(token, expected, &custom)
+func (k *Verifier) Verify(token string, exp jwt.Expected, extraDest ...any) (*jwt.Claims, error) {
+	tok, pub, err := k.parsedToken(token)
 	if err != nil {
+		return nil, err
+	}
+	cl := &jwt.Claims{}
+	dest := make([]any, 0, 1+len(extraDest))
+	dest = append(dest, cl)
+	dest = append(dest, extraDest...)
+	if err := tok.Claims(pub, dest...); err != nil {
 		return nil, err
 	}
 	// Verify that the expected claims satisfy the signed claims. Default leeway

--- a/token/jwt.go
+++ b/token/jwt.go
@@ -14,6 +14,20 @@ import (
 // corresponding key IDs matching the token header.
 var ErrKeyIDNotFound = errors.New("Key ID not found for given token header")
 
+// supportedAlgorithms lists the signature algorithms accepted during token parsing.
+var supportedAlgorithms = []jose.SignatureAlgorithm{
+	jose.EdDSA,
+	jose.ES256,
+	jose.RS256,
+}
+
+// IntegrationClaims contains M-Lab integration-specific JWT claims.
+// These identify which integrator and API key were used for a request.
+type IntegrationClaims struct {
+	IntegrationID string `json:"int_id,omitempty"`
+	KeyID         string `json:"key_id,omitempty"`
+}
+
 // ErrDuplicateKeyID is returned when initializing a verifier with multiple keys
 // with the same KeyID. KeyIDs should be unique.
 var ErrDuplicateKeyID = errors.New("Duplicate KeyID found")
@@ -54,6 +68,13 @@ func (k *Signer) Sign(cl jwt.Claims) (string, error) {
 	return k.Builder.Claims(cl).Serialize()
 }
 
+// SignWithIntegrationClaims signs standard JWT claims merged with integration
+// claims into a single token. go-jose's Builder.Claims() merges multiple
+// claim objects into one JWT payload.
+func (k *Signer) SignWithIntegrationClaims(cl jwt.Claims, ic IntegrationClaims) (string, error) {
+	return k.Builder.Claims(cl).Claims(ic).Serialize()
+}
+
 // JWKS returns a JSON Web Key Set containing the public key for this signer
 func (s *Signer) JWKS() jose.JSONWebKeySet {
 	return jose.JSONWebKeySet{
@@ -87,11 +108,7 @@ func NewVerifier(keys ...[]byte) (*Verifier, error) {
 // validate them against any expected claims. Useful for extracting
 // only the claims object.
 func (k *Verifier) Claims(token string) (*jwt.Claims, error) {
-	tok, err := jwt.ParseSigned(token, []jose.SignatureAlgorithm{
-		jose.EdDSA,
-		jose.ES256,
-		jose.RS256,
-	})
+	tok, err := jwt.ParseSigned(token, supportedAlgorithms)
 	if err != nil {
 		return nil, err
 	}
@@ -129,6 +146,33 @@ func (k *Verifier) Verify(token string, exp jwt.Expected) (*jwt.Claims, error) {
 	// for Validate() would be 1*time.Minute. This sets it to 0.
 	err = cl.ValidateWithLeeway(exp, 0)
 	return cl, err
+}
+
+// VerifyWithIntegrationClaims verifies the token and extracts both standard
+// and integration claims in a single parse pass. If the JWT does not contain
+// int_id/key_id fields, the returned IntegrationClaims will be zero-valued.
+func (k *Verifier) VerifyWithIntegrationClaims(token string, exp jwt.Expected) (*jwt.Claims, *IntegrationClaims, error) {
+	tok, err := jwt.ParseSigned(token, supportedAlgorithms)
+	if err != nil {
+		return nil, nil, err
+	}
+	headers := tok.Headers
+	if len(headers) == 0 {
+		return nil, nil, errors.New("no headers found in token")
+	}
+	keyID := headers[0].KeyID
+	pub, found := k.keys[keyID]
+	if !found {
+		return nil, nil, fmt.Errorf("%w: %s", ErrKeyIDNotFound, keyID)
+	}
+	cl := &jwt.Claims{}
+	ic := &IntegrationClaims{}
+	err = tok.Claims(pub, cl, ic)
+	if err != nil {
+		return nil, nil, err
+	}
+	err = cl.ValidateWithLeeway(exp, 0)
+	return cl, ic, err
 }
 
 // LoadJSONWebKey loads and validates the given JWK.

--- a/token/jwt.go
+++ b/token/jwt.go
@@ -21,13 +21,6 @@ var supportedAlgorithms = []jose.SignatureAlgorithm{
 	jose.RS256,
 }
 
-// IntegrationClaims contains M-Lab integration-specific JWT claims.
-// These identify which integrator and API key were used for a request.
-type IntegrationClaims struct {
-	IntegrationID string `json:"int_id,omitempty"`
-	KeyID         string `json:"key_id,omitempty"`
-}
-
 // ErrDuplicateKeyID is returned when initializing a verifier with multiple keys
 // with the same KeyID. KeyIDs should be unique.
 var ErrDuplicateKeyID = errors.New("Duplicate KeyID found")
@@ -39,8 +32,8 @@ type Verifier struct {
 
 // Signer is a JWT signer. Requires a private JWK.
 type Signer struct {
-	jwt.Builder
-	key *jose.JSONWebKey
+	builder jwt.Builder
+	key     *jose.JSONWebKey
 }
 
 // NewSigner accepts a serialized, private JWK and creates a new Signer instance.
@@ -49,30 +42,24 @@ func NewSigner(key []byte) (*Signer, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	opts := &jose.SignerOptions{}
-	signer, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.SignatureAlgorithm(priv.Algorithm), Key: priv}, opts)
+	signer, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.SignatureAlgorithm(priv.Algorithm), Key: priv}, &jose.SignerOptions{})
 	if err != nil {
 		return nil, err
 	}
-
-	p := &Signer{
-		Builder: jwt.Signed(signer),
+	return &Signer{
+		builder: jwt.Signed(signer),
 		key:     priv,
+	}, nil
+}
+
+// Sign signs the given claims and returns the serialized token. Optional extra
+// claim objects are merged into the JWT payload via go-jose's Builder.Claims().
+func (s *Signer) Sign(cl jwt.Claims, extra ...any) (string, error) {
+	b := s.builder.Claims(cl)
+	for _, e := range extra {
+		b = b.Claims(e)
 	}
-	return p, nil
-}
-
-// Sign signs the given claims and returns the serialized token.
-func (k *Signer) Sign(cl jwt.Claims) (string, error) {
-	return k.Builder.Claims(cl).Serialize()
-}
-
-// SignWithIntegrationClaims signs standard JWT claims merged with integration
-// claims into a single token. go-jose's Builder.Claims() merges multiple
-// claim objects into one JWT payload.
-func (k *Signer) SignWithIntegrationClaims(cl jwt.Claims, ic IntegrationClaims) (string, error) {
-	return k.Builder.Claims(cl).Claims(ic).Serialize()
+	return b.Serialize()
 }
 
 // JWKS returns a JSON Web Key Set containing the public key for this signer
@@ -146,33 +133,6 @@ func (k *Verifier) Verify(token string, exp jwt.Expected) (*jwt.Claims, error) {
 	// for Validate() would be 1*time.Minute. This sets it to 0.
 	err = cl.ValidateWithLeeway(exp, 0)
 	return cl, err
-}
-
-// VerifyWithIntegrationClaims verifies the token and extracts both standard
-// and integration claims in a single parse pass. If the JWT does not contain
-// int_id/key_id fields, the returned IntegrationClaims will be zero-valued.
-func (k *Verifier) VerifyWithIntegrationClaims(token string, exp jwt.Expected) (*jwt.Claims, *IntegrationClaims, error) {
-	tok, err := jwt.ParseSigned(token, supportedAlgorithms)
-	if err != nil {
-		return nil, nil, err
-	}
-	headers := tok.Headers
-	if len(headers) == 0 {
-		return nil, nil, errors.New("no headers found in token")
-	}
-	keyID := headers[0].KeyID
-	pub, found := k.keys[keyID]
-	if !found {
-		return nil, nil, fmt.Errorf("%w: %s", ErrKeyIDNotFound, keyID)
-	}
-	cl := &jwt.Claims{}
-	ic := &IntegrationClaims{}
-	err = tok.Claims(pub, cl, ic)
-	if err != nil {
-		return nil, nil, err
-	}
-	err = cl.ValidateWithLeeway(exp, 0)
-	return cl, ic, err
 }
 
 // LoadJSONWebKey loads and validates the given JWK.

--- a/token/jwt.go
+++ b/token/jwt.go
@@ -32,8 +32,8 @@ type Verifier struct {
 
 // Signer is a JWT signer. Requires a private JWK.
 type Signer struct {
-	builder jwt.Builder
-	key     *jose.JSONWebKey
+	signer jose.Signer
+	key    *jose.JSONWebKey
 }
 
 // NewSigner accepts a serialized, private JWK and creates a new Signer instance.
@@ -47,8 +47,8 @@ func NewSigner(key []byte) (*Signer, error) {
 		return nil, err
 	}
 	return &Signer{
-		builder: jwt.Signed(signer),
-		key:     priv,
+		signer: signer,
+		key:    priv,
 	}, nil
 }
 
@@ -58,7 +58,7 @@ func NewSigner(key []byte) (*Signer, error) {
 // standard claim wins: extras are applied first and cl last, so go-jose's
 // later-wins merge semantics make cl authoritative.
 func (s *Signer) Sign(cl jwt.Claims, extra ...any) (string, error) {
-	b := s.builder
+	b := jwt.Signed(s.signer)
 	for _, e := range extra {
 		b = b.Claims(e)
 	}

--- a/token/jwt.go
+++ b/token/jwt.go
@@ -129,15 +129,19 @@ func (k *Verifier) Claims(token string) (*jwt.Claims, error) {
 	return cl, nil
 }
 
-// Verify checks the token signature and validates claims against expected
-// values. Extra destination pointers are unmarshaled from the same JWT payload
-// via go-jose's variadic Claims support. For example:
+// Verify authenticates the token signature and policy-checks the standard
+// jwt.Claims against exp (iss, aud, exp, nbf, sub). Extra destination
+// pointers are unmarshaled from the same JWT payload via go-jose's variadic
+// Claims support. For example:
 //
 //	var custom MyCustomClaims
 //	cl, err := v.Verify(token, expected, &custom)
 //
-// If parsing succeeds but expected-claims validation fails, Verify returns the
-// parsed claims along with the non-nil validation error.
+// Fields in extraDest are JSON-unmarshaled only; no value-level check is
+// performed on them, that's the caller's responsibility.
+//
+// If parsing succeeds but expected-claims validation fails, Verify returns
+// the parsed claims along with the non-nil validation error.
 func (k *Verifier) Verify(token string, exp jwt.Expected, extraDest ...any) (*jwt.Claims, error) {
 	tok, pub, err := k.parsedToken(token)
 	if err != nil {

--- a/token/jwt.go
+++ b/token/jwt.go
@@ -54,12 +54,15 @@ func NewSigner(key []byte) (*Signer, error) {
 
 // Sign signs the given claims and returns the serialized token. Optional extra
 // claim objects are merged into the JWT payload via go-jose's Builder.Claims().
+// If a field in extra serializes to a JSON key that is also set by cl, the
+// standard claim wins: extras are applied first and cl last, so go-jose's
+// later-wins merge semantics make cl authoritative.
 func (s *Signer) Sign(cl jwt.Claims, extra ...any) (string, error) {
-	b := s.builder.Claims(cl)
+	b := s.builder
 	for _, e := range extra {
 		b = b.Claims(e)
 	}
-	return b.Serialize()
+	return b.Claims(cl).Serialize()
 }
 
 // JWKS returns a JSON Web Key Set containing the public key for this signer

--- a/token/jwt.go
+++ b/token/jwt.go
@@ -113,9 +113,10 @@ func (k *Verifier) parsedToken(token string) (*jwt.JSONWebToken, *jose.JSONWebKe
 	return tok, pub, nil
 }
 
-// Claims extracts the claims from a signed token, but does not
-// validate them against any expected claims. Useful for extracting
-// only the claims object.
+// Claims extracts the standard JWT claims from a signed token. It fails on
+// signature mismatch (or missing/unknown key ID); otherwise it returns the
+// claims as-is. The claim values are not validated against any jwt.Expected,
+// that's the caller's responsibility.
 func (k *Verifier) Claims(token string) (*jwt.Claims, error) {
 	tok, pub, err := k.parsedToken(token)
 	if err != nil {

--- a/token/jwt_test.go
+++ b/token/jwt_test.go
@@ -181,12 +181,15 @@ func TestLoadJSONWebKeyErrors(t *testing.T) {
 	}
 }
 
-func TestSignWithIntegrationClaims(t *testing.T) {
+func TestSignWithExtraClaims(t *testing.T) {
 	insecurePrivateTestKey := `{"use":"sig","kty":"EC","kid":"112","crv":"P-256","alg":"ES256",` +
 		`"x":"V0NoRfUZ-fPACALnakvKtTyXJ5JtgAWlWm-0NaDWUOE","y":"RDbGu6RVhgJGKCTuya4_IzZhT1GzlEIA5ZkumEZ35Ag",` +
 		`"d":"RXSpuTicBEL5GY-76cGgRXIEOB-q4hJ0vqydEnOztIY"}`
-	insecurePublicTestKey := `{"use":"sig","kty":"EC","kid":"112","crv":"P-256","alg":"ES256",` +
-		`"x":"V0NoRfUZ-fPACALnakvKtTyXJ5JtgAWlWm-0NaDWUOE","y":"RDbGu6RVhgJGKCTuya4_IzZhT1GzlEIA5ZkumEZ35Ag"}`
+
+	type customClaims struct {
+		Scope string `json:"scope,omitempty"`
+		Role  string `json:"role,omitempty"`
+	}
 
 	s, err := NewSigner([]byte(insecurePrivateTestKey))
 	if err != nil {
@@ -198,89 +201,24 @@ func TestSignWithIntegrationClaims(t *testing.T) {
 		Audience: jwt.Audience{"mlab1.fake0"},
 		Expiry:   jwt.NewNumericDate(time.Date(2030, time.January, 1, 0, 0, 0, 0, time.UTC)),
 	}
-	ic := IntegrationClaims{
-		IntegrationID: "test-integration",
-		KeyID:         "ki_abc123",
-	}
+	extra := customClaims{Scope: "read", Role: "admin"}
 
-	token, err := s.SignWithIntegrationClaims(cl, ic)
+	// Sign with extra claims.
+	token, err := s.Sign(cl, extra)
 	if err != nil {
-		t.Fatalf("SignWithIntegrationClaims failed: %v", err)
+		t.Fatalf("Sign with extra claims failed: %v", err)
 	}
 	if token == "" {
-		t.Fatal("SignWithIntegrationClaims returned empty token")
+		t.Fatal("Sign returned empty token")
 	}
 
-	// Verify the token contains integration claims by parsing it back.
-	v, err := NewVerifier([]byte(insecurePublicTestKey))
+	// Sign without extra claims still works.
+	token2, err := s.Sign(cl)
 	if err != nil {
-		t.Fatalf("NewVerifier failed: %v", err)
+		t.Fatalf("Sign without extra claims failed: %v", err)
 	}
-	exp := jwt.Expected{
-		Issuer:      "locate",
-		AnyAudience: jwt.Audience{"mlab1.fake0"},
-		Time:        time.Date(2029, time.December, 31, 0, 0, 0, 0, time.UTC),
-	}
-	verifiedCl, verifiedIC, err := v.VerifyWithIntegrationClaims(token, exp)
-	if err != nil {
-		t.Fatalf("VerifyWithIntegrationClaims failed: %v", err)
-	}
-	if verifiedCl.Issuer != "locate" {
-		t.Errorf("Expected issuer 'locate', got %q", verifiedCl.Issuer)
-	}
-	if verifiedIC.IntegrationID != "test-integration" {
-		t.Errorf("Expected int_id 'test-integration', got %q", verifiedIC.IntegrationID)
-	}
-	if verifiedIC.KeyID != "ki_abc123" {
-		t.Errorf("Expected key_id 'ki_abc123', got %q", verifiedIC.KeyID)
-	}
-}
-
-func TestVerifyWithIntegrationClaims_NoIntegrationClaims(t *testing.T) {
-	insecurePrivateTestKey := `{"use":"sig","kty":"EC","kid":"112","crv":"P-256","alg":"ES256",` +
-		`"x":"V0NoRfUZ-fPACALnakvKtTyXJ5JtgAWlWm-0NaDWUOE","y":"RDbGu6RVhgJGKCTuya4_IzZhT1GzlEIA5ZkumEZ35Ag",` +
-		`"d":"RXSpuTicBEL5GY-76cGgRXIEOB-q4hJ0vqydEnOztIY"}`
-	insecurePublicTestKey := `{"use":"sig","kty":"EC","kid":"112","crv":"P-256","alg":"ES256",` +
-		`"x":"V0NoRfUZ-fPACALnakvKtTyXJ5JtgAWlWm-0NaDWUOE","y":"RDbGu6RVhgJGKCTuya4_IzZhT1GzlEIA5ZkumEZ35Ag"}`
-
-	s, err := NewSigner([]byte(insecurePrivateTestKey))
-	if err != nil {
-		t.Fatalf("NewSigner failed: %v", err)
-	}
-
-	// Sign with standard claims only (no integration claims).
-	cl := jwt.Claims{
-		Issuer:   "locate",
-		Audience: jwt.Audience{"mlab1.fake0"},
-		Expiry:   jwt.NewNumericDate(time.Date(2030, time.January, 1, 0, 0, 0, 0, time.UTC)),
-	}
-	token, err := s.Sign(cl)
-	if err != nil {
-		t.Fatalf("Sign failed: %v", err)
-	}
-
-	// VerifyWithIntegrationClaims should succeed with empty integration claims.
-	v, err := NewVerifier([]byte(insecurePublicTestKey))
-	if err != nil {
-		t.Fatalf("NewVerifier failed: %v", err)
-	}
-	exp := jwt.Expected{
-		Issuer:      "locate",
-		AnyAudience: jwt.Audience{"mlab1.fake0"},
-		Time:        time.Date(2029, time.December, 31, 0, 0, 0, 0, time.UTC),
-	}
-	verifiedCl, verifiedIC, err := v.VerifyWithIntegrationClaims(token, exp)
-	if err != nil {
-		t.Fatalf("VerifyWithIntegrationClaims failed: %v", err)
-	}
-	if verifiedCl.Issuer != "locate" {
-		t.Errorf("Expected issuer 'locate', got %q", verifiedCl.Issuer)
-	}
-	if verifiedIC.IntegrationID != "" {
-		t.Errorf("Expected empty int_id, got %q", verifiedIC.IntegrationID)
-	}
-	if verifiedIC.KeyID != "" {
-		t.Errorf("Expected empty key_id, got %q", verifiedIC.KeyID)
+	if token2 == "" {
+		t.Fatal("Sign returned empty token")
 	}
 }
 

--- a/token/jwt_test.go
+++ b/token/jwt_test.go
@@ -222,6 +222,70 @@ func TestSignWithExtraClaims(t *testing.T) {
 	}
 }
 
+func TestVerifyWithExtraClaims(t *testing.T) {
+	insecurePrivateTestKey := `{"use":"sig","kty":"EC","kid":"112","crv":"P-256","alg":"ES256",` +
+		`"x":"V0NoRfUZ-fPACALnakvKtTyXJ5JtgAWlWm-0NaDWUOE","y":"RDbGu6RVhgJGKCTuya4_IzZhT1GzlEIA5ZkumEZ35Ag",` +
+		`"d":"RXSpuTicBEL5GY-76cGgRXIEOB-q4hJ0vqydEnOztIY"}`
+	insecurePublicTestKey := `{"use":"sig","kty":"EC","kid":"112","crv":"P-256","alg":"ES256",` +
+		`"x":"V0NoRfUZ-fPACALnakvKtTyXJ5JtgAWlWm-0NaDWUOE","y":"RDbGu6RVhgJGKCTuya4_IzZhT1GzlEIA5ZkumEZ35Ag"}`
+
+	type customClaims struct {
+		Scope string `json:"scope,omitempty"`
+		Role  string `json:"role,omitempty"`
+	}
+
+	s, err := NewSigner([]byte(insecurePrivateTestKey))
+	if err != nil {
+		t.Fatalf("NewSigner failed: %v", err)
+	}
+	v, err := NewVerifier([]byte(insecurePublicTestKey))
+	if err != nil {
+		t.Fatalf("NewVerifier failed: %v", err)
+	}
+
+	cl := jwt.Claims{
+		Issuer:   "locate",
+		Audience: jwt.Audience{"mlab1.fake0"},
+		Expiry:   jwt.NewNumericDate(time.Date(2030, time.January, 1, 0, 0, 0, 0, time.UTC)),
+	}
+	extra := customClaims{Scope: "read", Role: "admin"}
+
+	tok, err := s.Sign(cl, extra)
+	if err != nil {
+		t.Fatalf("Sign failed: %v", err)
+	}
+
+	// Verify with extra destination.
+	exp := jwt.Expected{
+		Issuer:      "locate",
+		AnyAudience: jwt.Audience{"mlab1.fake0"},
+		Time:        time.Date(2029, time.December, 31, 0, 0, 0, 0, time.UTC),
+	}
+	var got customClaims
+	verified, err := v.Verify(tok, exp, &got)
+	if err != nil {
+		t.Fatalf("Verify failed: %v", err)
+	}
+	if verified.Issuer != "locate" {
+		t.Errorf("Expected issuer 'locate', got %q", verified.Issuer)
+	}
+	if got.Scope != "read" {
+		t.Errorf("Expected scope 'read', got %q", got.Scope)
+	}
+	if got.Role != "admin" {
+		t.Errorf("Expected role 'admin', got %q", got.Role)
+	}
+
+	// Verify without extra destination still works.
+	verified2, err := v.Verify(tok, exp)
+	if err != nil {
+		t.Fatalf("Verify without extra failed: %v", err)
+	}
+	if verified2.Issuer != "locate" {
+		t.Errorf("Expected issuer 'locate', got %q", verified2.Issuer)
+	}
+}
+
 func TestSignerJWKS(t *testing.T) {
 	insecurePrivateTestKey := `{"use":"sig","kty":"EC","kid":"112","crv":"P-256","alg":"ES256",` +
 		`"x":"V0NoRfUZ-fPACALnakvKtTyXJ5JtgAWlWm-0NaDWUOE","y":"RDbGu6RVhgJGKCTuya4_IzZhT1GzlEIA5ZkumEZ35Ag",` +

--- a/token/jwt_test.go
+++ b/token/jwt_test.go
@@ -181,6 +181,109 @@ func TestLoadJSONWebKeyErrors(t *testing.T) {
 	}
 }
 
+func TestSignWithIntegrationClaims(t *testing.T) {
+	insecurePrivateTestKey := `{"use":"sig","kty":"EC","kid":"112","crv":"P-256","alg":"ES256",` +
+		`"x":"V0NoRfUZ-fPACALnakvKtTyXJ5JtgAWlWm-0NaDWUOE","y":"RDbGu6RVhgJGKCTuya4_IzZhT1GzlEIA5ZkumEZ35Ag",` +
+		`"d":"RXSpuTicBEL5GY-76cGgRXIEOB-q4hJ0vqydEnOztIY"}`
+	insecurePublicTestKey := `{"use":"sig","kty":"EC","kid":"112","crv":"P-256","alg":"ES256",` +
+		`"x":"V0NoRfUZ-fPACALnakvKtTyXJ5JtgAWlWm-0NaDWUOE","y":"RDbGu6RVhgJGKCTuya4_IzZhT1GzlEIA5ZkumEZ35Ag"}`
+
+	s, err := NewSigner([]byte(insecurePrivateTestKey))
+	if err != nil {
+		t.Fatalf("NewSigner failed: %v", err)
+	}
+
+	cl := jwt.Claims{
+		Issuer:   "locate",
+		Audience: jwt.Audience{"mlab1.fake0"},
+		Expiry:   jwt.NewNumericDate(time.Date(2030, time.January, 1, 0, 0, 0, 0, time.UTC)),
+	}
+	ic := IntegrationClaims{
+		IntegrationID: "test-integration",
+		KeyID:         "ki_abc123",
+	}
+
+	token, err := s.SignWithIntegrationClaims(cl, ic)
+	if err != nil {
+		t.Fatalf("SignWithIntegrationClaims failed: %v", err)
+	}
+	if token == "" {
+		t.Fatal("SignWithIntegrationClaims returned empty token")
+	}
+
+	// Verify the token contains integration claims by parsing it back.
+	v, err := NewVerifier([]byte(insecurePublicTestKey))
+	if err != nil {
+		t.Fatalf("NewVerifier failed: %v", err)
+	}
+	exp := jwt.Expected{
+		Issuer:      "locate",
+		AnyAudience: jwt.Audience{"mlab1.fake0"},
+		Time:        time.Date(2029, time.December, 31, 0, 0, 0, 0, time.UTC),
+	}
+	verifiedCl, verifiedIC, err := v.VerifyWithIntegrationClaims(token, exp)
+	if err != nil {
+		t.Fatalf("VerifyWithIntegrationClaims failed: %v", err)
+	}
+	if verifiedCl.Issuer != "locate" {
+		t.Errorf("Expected issuer 'locate', got %q", verifiedCl.Issuer)
+	}
+	if verifiedIC.IntegrationID != "test-integration" {
+		t.Errorf("Expected int_id 'test-integration', got %q", verifiedIC.IntegrationID)
+	}
+	if verifiedIC.KeyID != "ki_abc123" {
+		t.Errorf("Expected key_id 'ki_abc123', got %q", verifiedIC.KeyID)
+	}
+}
+
+func TestVerifyWithIntegrationClaims_NoIntegrationClaims(t *testing.T) {
+	insecurePrivateTestKey := `{"use":"sig","kty":"EC","kid":"112","crv":"P-256","alg":"ES256",` +
+		`"x":"V0NoRfUZ-fPACALnakvKtTyXJ5JtgAWlWm-0NaDWUOE","y":"RDbGu6RVhgJGKCTuya4_IzZhT1GzlEIA5ZkumEZ35Ag",` +
+		`"d":"RXSpuTicBEL5GY-76cGgRXIEOB-q4hJ0vqydEnOztIY"}`
+	insecurePublicTestKey := `{"use":"sig","kty":"EC","kid":"112","crv":"P-256","alg":"ES256",` +
+		`"x":"V0NoRfUZ-fPACALnakvKtTyXJ5JtgAWlWm-0NaDWUOE","y":"RDbGu6RVhgJGKCTuya4_IzZhT1GzlEIA5ZkumEZ35Ag"}`
+
+	s, err := NewSigner([]byte(insecurePrivateTestKey))
+	if err != nil {
+		t.Fatalf("NewSigner failed: %v", err)
+	}
+
+	// Sign with standard claims only (no integration claims).
+	cl := jwt.Claims{
+		Issuer:   "locate",
+		Audience: jwt.Audience{"mlab1.fake0"},
+		Expiry:   jwt.NewNumericDate(time.Date(2030, time.January, 1, 0, 0, 0, 0, time.UTC)),
+	}
+	token, err := s.Sign(cl)
+	if err != nil {
+		t.Fatalf("Sign failed: %v", err)
+	}
+
+	// VerifyWithIntegrationClaims should succeed with empty integration claims.
+	v, err := NewVerifier([]byte(insecurePublicTestKey))
+	if err != nil {
+		t.Fatalf("NewVerifier failed: %v", err)
+	}
+	exp := jwt.Expected{
+		Issuer:      "locate",
+		AnyAudience: jwt.Audience{"mlab1.fake0"},
+		Time:        time.Date(2029, time.December, 31, 0, 0, 0, 0, time.UTC),
+	}
+	verifiedCl, verifiedIC, err := v.VerifyWithIntegrationClaims(token, exp)
+	if err != nil {
+		t.Fatalf("VerifyWithIntegrationClaims failed: %v", err)
+	}
+	if verifiedCl.Issuer != "locate" {
+		t.Errorf("Expected issuer 'locate', got %q", verifiedCl.Issuer)
+	}
+	if verifiedIC.IntegrationID != "" {
+		t.Errorf("Expected empty int_id, got %q", verifiedIC.IntegrationID)
+	}
+	if verifiedIC.KeyID != "" {
+		t.Errorf("Expected empty key_id, got %q", verifiedIC.KeyID)
+	}
+}
+
 func TestSignerJWKS(t *testing.T) {
 	insecurePrivateTestKey := `{"use":"sig","kty":"EC","kid":"112","crv":"P-256","alg":"ES256",` +
 		`"x":"V0NoRfUZ-fPACALnakvKtTyXJ5JtgAWlWm-0NaDWUOE","y":"RDbGu6RVhgJGKCTuya4_IzZhT1GzlEIA5ZkumEZ35Ag",` +

--- a/token/jwt_test.go
+++ b/token/jwt_test.go
@@ -222,6 +222,70 @@ func TestSignWithExtraClaims(t *testing.T) {
 	}
 }
 
+// TestSignExtraClaimsCannotOverrideStandard asserts that a caller-supplied
+// extra claim struct whose JSON tags collide with standard jwt.Claims keys
+// (iss, aud, sub) cannot overwrite the values set via the standard claims
+// argument: the standard claims must win.
+func TestSignExtraClaimsCannotOverrideStandard(t *testing.T) {
+	insecurePrivateTestKey := `{"use":"sig","kty":"EC","kid":"112","crv":"P-256","alg":"ES256",` +
+		`"x":"V0NoRfUZ-fPACALnakvKtTyXJ5JtgAWlWm-0NaDWUOE","y":"RDbGu6RVhgJGKCTuya4_IzZhT1GzlEIA5ZkumEZ35Ag",` +
+		`"d":"RXSpuTicBEL5GY-76cGgRXIEOB-q4hJ0vqydEnOztIY"}`
+	insecurePublicTestKey := `{"use":"sig","kty":"EC","kid":"112","crv":"P-256","alg":"ES256",` +
+		`"x":"V0NoRfUZ-fPACALnakvKtTyXJ5JtgAWlWm-0NaDWUOE","y":"RDbGu6RVhgJGKCTuya4_IzZhT1GzlEIA5ZkumEZ35Ag"}`
+
+	type collider struct {
+		Iss string `json:"iss"`
+		Aud string `json:"aud"`
+		Sub string `json:"sub"`
+	}
+
+	s, err := NewSigner([]byte(insecurePrivateTestKey))
+	if err != nil {
+		t.Fatalf("NewSigner failed: %v", err)
+	}
+	v, err := NewVerifier([]byte(insecurePublicTestKey))
+	if err != nil {
+		t.Fatalf("NewVerifier failed: %v", err)
+	}
+
+	cl := jwt.Claims{
+		Issuer:   "standard-iss",
+		Audience: jwt.Audience{"standard-aud"},
+		Subject:  "standard-sub",
+		Expiry:   jwt.NewNumericDate(time.Date(2030, time.January, 1, 0, 0, 0, 0, time.UTC)),
+	}
+	bad := collider{
+		Iss: "attacker-iss",
+		Aud: "attacker-aud",
+		Sub: "attacker-sub",
+	}
+
+	tok, err := s.Sign(cl, bad)
+	if err != nil {
+		t.Fatalf("Sign failed: %v", err)
+	}
+
+	exp := jwt.Expected{
+		Issuer:      "standard-iss",
+		AnyAudience: jwt.Audience{"standard-aud"},
+		Subject:     "standard-sub",
+		Time:        time.Date(2029, time.December, 31, 0, 0, 0, 0, time.UTC),
+	}
+	verified, err := v.Verify(tok, exp)
+	if err != nil {
+		t.Fatalf("Verify rejected token whose standard claims should have won: %v", err)
+	}
+	if verified.Issuer != "standard-iss" {
+		t.Errorf("Issuer: got %q, want %q", verified.Issuer, "standard-iss")
+	}
+	if len(verified.Audience) != 1 || verified.Audience[0] != "standard-aud" {
+		t.Errorf("Audience: got %v, want [standard-aud]", verified.Audience)
+	}
+	if verified.Subject != "standard-sub" {
+		t.Errorf("Subject: got %q, want %q", verified.Subject, "standard-sub")
+	}
+}
+
 func TestVerifyWithExtraClaims(t *testing.T) {
 	insecurePrivateTestKey := `{"use":"sig","kty":"EC","kid":"112","crv":"P-256","alg":"ES256",` +
 		`"x":"V0NoRfUZ-fPACALnakvKtTyXJ5JtgAWlWm-0NaDWUOE","y":"RDbGu6RVhgJGKCTuya4_IzZhT1GzlEIA5ZkumEZ35Ag",` +


### PR DESCRIPTION
Locate (the m-lab locate service) issues JWTs that need to carry the ID of the integration that requested the token. ndt-server verifies those JWTs before running a test and attaches the integration ID to test results for downstream attribution. Both use this library to sign/validate and extract claims.

This PR adds the ability to add custom claims to the JWT. Specifically:

- `Signer.Sign(cl jwt.Claims, extra ...any) (string, error)`: optional extra
  claim objects are merged into the JWT payload alongside the standard claims.
- `Verifier.Verify(token string, exp jwt.Expected, extraDest ...any) (*jwt.Claims, error)`:
  optional extra destination pointers are unmarshaled from the same payload.

Standard `jwt.Claims` win on any JSON-key collision with an extra struct, so a custom field cannot silently overwrite `iss`/`aud`/`exp`/`nbf`/`sub`.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/access/43)
<!-- Reviewable:end -->
